### PR TITLE
Add support for IAM instance profiles

### DIFF
--- a/docs/config.template
+++ b/docs/config.template
@@ -74,6 +74,10 @@
 #                      Valid values: `True`, `False`. Default is `False`
 # vpc:      the name or ID of the AWS Virtual Private Cloud to provision
 #           resources in.
+# instance_profile: an IAM instance profile that contains roles allowing
+#                   EC2 instances to have specified privileges. For example,
+#                   you can allow EC2 instances to access S3 without
+#                   passing credentials in.
 #
 # **OpenStack users**: from the web interface you can download a file
 # containing your EC2 credentials by logging in in your provider web

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -158,6 +158,13 @@ Valid configuration keys for `boto`
     will force `elasticluster` to request such a floating IP if the
     instance doesn't get one automatically.
 
+``instance_profile``
+
+     An `IAM instance profile
+     <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_
+     that contains roles allowing EC2 instances to have specified
+     privileges. For example, you can allow EC2 instances to access S3 without
+     passing credentials in.
 
 Valid configuration keys for `google`
 -------------------------------------

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -412,6 +412,7 @@ class ConfigValidator(object):
                             "ec2_region": All(str, Length(min=1)),
                             Optional("request_floating_ip"): Boolean(str),
                             Optional("vpc"): All(str, Length(min=1)),
+                            Optional("instance_profile"): All(str, Length(min=1)),
         }
         cloud_schema_gce = {"provider": 'google',
                             "gce_client_id": All(str, Length(min=1)),

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -50,16 +50,19 @@ class BotoCloudProvider(AbstractCloudProvider):
     :param bool request_floating_ip: Whether ip are assigned automatically
                                     `True` or floating ips have to be
                                     assigned manually `False`
+    :param str instance_profile: Instance profile with IAM role permissions
     """
     __node_start_lock = threading.Lock()  # lock used for node startup
 
     def __init__(self, ec2_url, ec2_region, ec2_access_key, ec2_secret_key,
-                 vpc=None, storage_path=None, request_floating_ip=False):
+                 vpc=None, storage_path=None, request_floating_ip=False,
+                 instance_profile=None):
         self._url = ec2_url
         self._region_name = ec2_region
         self._access_key = ec2_access_key
         self._secret_key = ec2_secret_key
         self._vpc = vpc
+        self._instance_profile = instance_profile
         self.request_floating_ip = request_floating_ip
 
         # read all parameters from url
@@ -204,7 +207,8 @@ class BotoCloudProvider(AbstractCloudProvider):
             reservation = connection.run_instances(
                 image_id, key_name=key_name, security_groups=security_groups,
                 instance_type=flavor, user_data=image_userdata,
-                network_interfaces=interfaces)
+                network_interfaces=interfaces,
+                instance_profile_name=self._instance_profile)
         except Exception, ex:
             log.error("Error starting instance: %s", ex)
             if "TooManyInstances" in ex:


### PR DESCRIPTION
Hi Antonio, this change (by @chapmanb) lets you apply IAM profiles to instances, letting them do things like interact with S3 without having to explicitly specify credentials.