### PR TITLE
Calculate AWS key fingerprints the same way AWS does

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ from setuptools import setup, find_packages
 
 required_packages = [
     'PyCLI',
+    'pycrypto',
     'paramiko',
     'ansible',
     'voluptuous',


### PR DESCRIPTION
Thanks to these forum posts:

https://forums.aws.amazon.com/message.jspa?messageID=307410
http://stackoverflow.com/questions/21709817/printing-pem-key-der-form-in-python

I added support for calculating AWS key fingerprints, which eliminates the warning on cluster start.
