### PR TITLE
Fetch hostkeys securely from launched instances

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -580,6 +580,13 @@ Optional configuration keys
     The maximum number of process to be created when virtual machines
     are started. Default is 10.
 
+``ssh_hostkeys_from_console_output``
+
+    whether to retrieve SSH host keys from instances' console output,
+    instead of accepting the host keys without verification when connecting
+    via SSH for the first time. Only supported when the cloud provider is
+    `ec2_boto`
+
 Examples
 --------
 

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -391,6 +391,7 @@ class ConfigValidator(object):
         schema = {"cluster": {"cloud": All(str, Length(min=1)),
                               "setup_provider": All(str, Length(min=1)),
                               "login": All(str, Length(min=1)),
+                              Optional("ssh_hostkeys_from_console_output"): Boolean(str),
                           },
                   "setup": {"provider": All(str, Length(min=1)),
                             Optional("playbook_path"): check_file(),

--- a/elasticluster/providers/__init__.py
+++ b/elasticluster/providers/__init__.py
@@ -88,6 +88,15 @@ class AbstractCloudProvider:
         """
         pass
 
+    def get_console_output(self, instance_id):
+        """Returns an instance's console output.
+
+        :param str instance_id: instance identifier
+
+        :return: str - instance console output
+        """
+        pass
+
 
 class AbstractSetupProvider:
     """

--- a/elasticluster/providers/ansible_provider.py
+++ b/elasticluster/providers/ansible_provider.py
@@ -162,10 +162,12 @@ class AnsibleSetupProvider(AbstractSetupProvider):
         private_key_file = cluster.user_key_private
 
         # update ansible constants
-        ansible_constants.HOST_KEY_CHECKING = False
+        ansible_constants.HOST_KEY_CHECKING = True
         ansible_constants.DEFAULT_PRIVATE_KEY_FILE = private_key_file
         ansible_constants.DEFAULT_SUDO_USER = self._sudo_user
         ansible_constants.ANSIBLE_SSH_PIPELINING = self.ssh_pipelining
+        ansible_constants.ANSIBLE_SSH_ARGS = (
+            '-o UserKnownHostsFile={}'.format(cluster.known_hosts_file))
 
         # check paths
         if not inventory_path:

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -263,6 +263,10 @@ class BotoCloudProvider(AbstractCloudProvider):
         instance = self._load_instance(instance_id)
 
         if instance.update() == "running":
+            output = instance.get_console_output()
+            if not output.output:
+                return False
+
             # If the instance is up&running, ensure it has an IP
             # address.
             if not instance.ip_address and self.request_floating_ip:
@@ -509,3 +513,7 @@ class BotoCloudProvider(AbstractCloudProvider):
         self._ec2_connection = None
         self._vpc_connection = None
         
+    def get_console_output(self, instance_id):
+        instance = self._load_instance(instance_id)
+        instance.update()
+        return instance.get_console_output().output


### PR DESCRIPTION
Hi Antonio, this implements the changes you suggested in https://github.com/gc3-uzh-ch/elasticluster/issues/116 to fetch SSH host keys from EC2 instances via the AWS API.
