### PR TITLE
Update the instructions for obtaining the client_id and client_secret for Google Compute Engine

### DIFF
--- a/docs/config.template
+++ b/docs/config.template
@@ -474,6 +474,16 @@ worker_groups=ipython_engine
 #          configured anyway, otherwise creation of the cluster will
 #          fail.
 #
+# boot_disk_type: Define the type of boot disk to use.
+#                 Only supported when the cloud provider is google.
+#                 Supported values are pd-standard and pd-ssd.
+#                 Default value is pd-standard.
+#
+# boot_disk_size: Define the size of boot disk to use.
+#                 Only supported when the cloud provider is google.
+#                 Values are specified in gigabytes.
+#                 Default value is 10.
+
 # Some (working) examples:
 
 [cluster/slurm]

--- a/docs/config.template
+++ b/docs/config.template
@@ -93,9 +93,9 @@
 #
 # Valid configuration keys for *google*
 # -------------------------------------
-# gce_client_id:     The API client id generated in the Google API Console
+# gce_client_id:     The API client id generated in the Google Developers Console
 #
-# gce_client_secret: The API client secret generated in the Google API Console
+# gce_client_secret: The API client secret generated in the Google Developers Console
 #
 # gce_project_id:    The project id of your Google Compute Engine project
 #
@@ -132,22 +132,28 @@
 #                      Valid values: `True`, `False`. Default is `False`
 #
 #
-# API Console
-# +++++++++++
+# Google Compute Engine users
+# +++++++++++++++++++++++++++
 #
 # To generate a client_id and client_secret to access the Google Compute
-# Engine visit the following page: https://code.google.com/apis/console/
+# Engine visit the following page:
 #
-# 1. Select the project defined as gce_project_id
-# 2. Navigate to `API Access`
-# 3. Click create another client id
-# 4. Select `Installed Application` -> `Other`
-# 5. After clicking the `Create` button you'll see your client_id and
-#    secret_key in the list of available client ids
+#   https://console.developers.google.com/project/_/apiui/credential
 #
-# **Please note**: you have to set your google username in the login
-# section below as `image_user` to be able to use Google Compute
-# Engine
+# 1. Select the project to be used for your cluster
+# 2. If a "Client ID for native application" is listed on this page,
+#    skip to step 8
+# 3. Under the OAuth section, click "Create new Client ID"
+# 4. Select "Installed Application"
+# 5. If prompted, click "Configure consent screen" and follow the
+#    instructions to set a "product name" to identify your Cloud
+#    project in the consent screen
+# 6. In the Create Client ID dialog, be sure the following are selected:
+#      Application type: Installed application
+#      Installed application type: Other
+# 7. Click the "Create Client ID" button
+# 8. You'll see your Client ID and Client secret listed under
+#    "Client ID for native application"
 #
 #
 #

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -587,6 +587,18 @@ Optional configuration keys
     The maximum number of process to be created when virtual machines
     are started. Default is 10.
 
+``boot_disk_type``
+    Define the type of boot disk to use.
+    Only supported when the cloud provider is `google`.
+    Supported values are `pd-standard` and `pd-ssd`.
+    Default value is `pd-standard`.
+
+``boot_disk_size``
+    Define the size of boot disk to use.
+    Only supported when the cloud provider is `google`.
+    Values are specified in gigabytes.
+    Default value is 10.
+
 Examples
 --------
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -164,11 +164,11 @@ Valid configuration keys for `google`
 
 ``gce_client_id``
 
-    The API client id generated in the Google API Console
+    The API client id generated in the Google Developers Console
 
 ``gce_client_secret``
 
-    The API client secret generated in the Google API Console
+    The API client secret generated in the Google Developers Console
 
 ``gce_project_id``
 
@@ -276,17 +276,24 @@ configuration file:
 Google Compute Engine users
 +++++++++++++++++++++++++++
 To generate a client_id and client_secret to access the Google Compute
-Engine visit the following page: https://code.google.com/apis/console/
+Engine visit the following page:
 
-1. Select the project defined as gce_project_id
-2. Navigate to `API Access`
-3. Click create another client id
-4. Select `Installed Application` -> `Other`
-5. After clicking the `Create` button you'll see your client_id and
-   secret_key in the list of available client ids
+  https://console.developers.google.com/project/_/apiui/credential
 
-**Please note**: you have to set your google username in the login section  below as image_user to be able to use Google Compute Engine
-
+1. Select the project to be used for your cluster
+2. If a "Client ID for native application" is listed on this page,
+   skip to step 8
+3. Under the OAuth section, click "Create new Client ID"
+4. Select "Installed Application"
+5. If prompted, click "Configure consent screen" and follow the
+   instructions to set a "product name" to identify your Cloud
+   project in the consent screen
+6. In the Create Client ID dialog, be sure the following are selected:
+     *Application type*: Installed application
+     *Installed application type*: Other
+7. Click the "Create Client ID" button
+8. You'll see your Client ID and Client secret listed under
+   "Client ID for native application"
 
 Login Section
 ===============

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -289,8 +289,8 @@ Engine visit the following page:
    instructions to set a "product name" to identify your Cloud
    project in the consent screen
 6. In the Create Client ID dialog, be sure the following are selected:
-     *Application type*: Installed application
-     *Installed application type*: Other
+     => Application type: Installed application
+     => Installed application type: Other
 7. Click the "Create Client ID" button
 8. You'll see your Client ID and Client secret listed under
    "Client ID for native application"

--- a/docs/html/configure.html
+++ b/docs/html/configure.html
@@ -551,6 +551,19 @@ up&amp;running to configure the cluster. When starting a cluster,
 creation of some instances may fail. If at least min_nodes are
 started correctly (i.e. are not in error state), the cluster is
 configured anyway, otherwise creation of the cluster will fail.</div></blockquote>
+<p><tt class="docutils literal"><span class="pre">boot_disk_type</span></tt></p>
+<blockquote>
+<div>Define the type of boot disk to use.
+Only supported when the cloud provider is <cite>google</cite>.
+Supported values are <em>pd-standard</em> and <em>pd-ssd</em>. 
+Default value is <em>pd-standard</em>.
+</div></blockquote>
+<p><tt class="docutils literal"><span class="pre">boot_disk_size</span></tt></p>
+<blockquote>
+<div>Define the size of boot disk to use.
+Only supported when the cloud provider is <cite>google</cite>.
+Value is specified in gigabytes.  Default value is 10.
+</div></blockquote>
 </div>
 <div class="section" id="id5">
 <h3>Examples<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>

--- a/docs/html/configure.html
+++ b/docs/html/configure.html
@@ -180,10 +180,10 @@ instance doesn&#8217;t get one automatically.</div></blockquote>
 <h3>Valid configuration keys for <cite>google</cite><a class="headerlink" href="#valid-configuration-keys-for-google" title="Permalink to this headline">¶</a></h3>
 <p><tt class="docutils literal"><span class="pre">gce_client_id</span></tt></p>
 <blockquote>
-<div>The API client id generated in the Google API Console</div></blockquote>
+<div>The API client id generated in the Google Developers Console</div></blockquote>
 <p><tt class="docutils literal"><span class="pre">gce_client_secret</span></tt></p>
 <blockquote>
-<div>The API client secret generated in the Google API Console</div></blockquote>
+<div>The API client secret generated in the Google Developers Console</div></blockquote>
 <p><tt class="docutils literal"><span class="pre">gce_project_id</span></tt></p>
 <blockquote>
 <div>The project id of your Google Compute Engine project</div></blockquote>
@@ -283,16 +283,19 @@ configuration file:</p>
 <div class="section" id="google-compute-engine-users">
 <h4>Google Compute Engine users<a class="headerlink" href="#google-compute-engine-users" title="Permalink to this headline">¶</a></h4>
 <p>To generate a client_id and client_secret to access the Google Compute
-Engine visit the following page: <a class="reference external" href="https://code.google.com/apis/console/">https://code.google.com/apis/console/</a></p>
+Engine visit the following page: <a class="reference external" href="https://console.developers.google.com/project/_/apiui/credential" target=_blank>https://console.developers.google.com/project/_/apiui/credential</a></p>
 <ol class="arabic simple">
-<li>Select the project defined as gce_project_id</li>
-<li>Navigate to <cite>API Access</cite></li>
-<li>Click create another client id</li>
-<li>Select <cite>Installed Application</cite> -&gt; <cite>Other</cite></li>
-<li>After clicking the <cite>Create</cite> button you&#8217;ll see your client_id and
-secret_key in the list of available client ids</li>
+<li>Select the project to be used for your cluster</li>
+<li>If a "Client ID for native application" is listed on this page, skip to step 8</li>
+<li>Under the OAuth section, click "Create new Client ID"</li>
+<li>Select "Installed Application"</li>
+<li>If prompted, click "Configure consent screen" and follow the instructions to set a "product name" to identify your Cloud project in the consent screen</li>
+<li>In the Create Client ID dialog, be sure the following are selected:<br>
+&nbsp;&nbsp;<b>Application type</b>: Installed application<br>
+&nbsp;&nbsp;<b>Installed application type</b>: Other</li>
+<li>Click the "Create Client ID" button</li>
+<li>You'll see your Client ID and Client secret listed under "Client ID for native application"</li>
 </ol>
-<p><strong>Please note</strong>: you have to set your google username in the login section  below as image_user to be able to use Google Compute Engine</p>
 </div>
 </div>
 </div>

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -212,7 +212,10 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        username=None,
                        # these params are specific to the
                        # GoogleCloudProvider
-                       instance_name=None, **kwargs):
+                       instance_name=None,
+                       boot_disk_type='pd-standard',
+                       boot_disk_size=10,
+                       **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
 
@@ -234,6 +237,9 @@ class GoogleCloudProvider(AbstractCloudProvider):
         project_url = '%s%s' % (GCE_URL, self._project_id)
         machine_type_url = '%s/zones/%s/machineTypes/%s' \
                            % (project_url, self._zone, flavor)
+        boot_disk_type_url = '%s/zones/%s/diskTypes/%s' \
+                           % (project_url, self._zone, boot_disk_type)
+        boot_disk_size_gb = boot_disk_size
         network_url = '%s/global/networks/%s' % (project_url, self._network)
         if image_id.startswith('http://') or image_id.startswith('https://'):
             image_url = image_id
@@ -258,6 +264,8 @@ class GoogleCloudProvider(AbstractCloudProvider):
                 'type': 'PERSISTENT',
                 'initializeParams' : {
                     'diskName': "%s-disk" % instance_name,
+                    'diskType': boot_disk_type_url,
+                    'diskSizeGb': boot_disk_size_gb,
                     'sourceImage': image_url
                     }
                 }],


### PR DESCRIPTION
Also removed the note in the Google-specific section regarding image_user as it is called out in the generic "Mandatory configuration keys".