### PR TITLE
Update deprecated python2 exception style

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -612,7 +612,7 @@ class Cluster(object):
         try:
             # setup the cluster using the setup provider
             ret = self._setup_provider.setup_cluster(self)
-        except Exception, e:
+        except Exception as e:
             log.error(
                 "the setup provider was not able to setup the cluster, "
                 "but the cluster is running by now. Setup provider error "
@@ -635,7 +635,7 @@ class Cluster(object):
         for node in self.get_all_nodes():
             try:
                 node.update_ips()
-            except InstanceError, ex:
+            except InstanceError as ex:
                 log.warning("Ignoring error updating information on node %s: %s",
                           node, str(ex))
         self.repository.save_or_update(self)
@@ -744,7 +744,7 @@ class Node(object):
                       self.instance_id)
             running = self._cloud_provider.is_instance_running(
                 self.instance_id)
-        except Exception, ex:
+        except Exception as ex:
             log.debug("Ignoring error while looking for vm id %s: %s",
                       self.instance_id, str(ex))
         if running:
@@ -805,10 +805,10 @@ class Node(object):
                     cluster_changed = True
                 # Connection successful.
                 return ssh
-            except socket.error, ex:
+            except socket.error as ex:
                 log.debug("Host %s (%s) not reachable: %s.",
                           self.name, ip, ex)
-            except paramiko.SSHException, ex:
+            except paramiko.SSHException as ex:
                 log.debug("Ignoring error %s connecting to %s",
                           str(ex), self.name)
 

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -158,7 +158,7 @@ class Configurator(object):
                 provider = GoogleCloudProvider
             else:
                 raise Invalid("Invalid provider '%s' for cluster '%s'"% (conf['provider'], cluster_template))
-        except ImportError, ex:
+        except ImportError as ex:
             raise Invalid("Unable to load provider '%s': %s" % (conf['provider'], ex))
 
         providerconf = conf.copy()
@@ -620,33 +620,33 @@ class ConfigReader(object):
             try:
                 values['setup'] = dict(self.conf[setup_name])
                 self.schemas['setup'](values['setup'])
-            except KeyError, ex:
+            except KeyError as ex:
                 errors.add(
                     "cluster `%s` setup section `%s` does not exists" % (
                         cluster, setup_name))
-            except MultipleInvalid, ex:
+            except MultipleInvalid as ex:
                 for error in ex.errors:
                     errors.add(error)
 
             try:
                 values['login'] = dict(self.conf[login_name])
                 self.schemas['login'](values['login'])
-            except KeyError, ex:
+            except KeyError as ex:
                 errors.add(
                     "cluster `%s` login section `%s` does not exists" % (
                         cluster, login_name))
-            except MultipleInvalid, ex:
+            except MultipleInvalid as ex:
                 errors.add(Invalid("Error in login section `%s`: %s" % (
                     login_name, str.join(', ', [str(e) for e in ex.errors]))))
 
             try:
                 values['cloud'] = dict(self.conf[cloud_name])
                 self.schemas['cloud'](values['cloud'])
-            except KeyError, ex:
+            except KeyError as ex:
                 errors.add(
                     "cluster `%s` cloud section `%s` does not exists" % (
                         cluster, cloud_name))
-            except MultipleInvalid, ex:
+            except MultipleInvalid as ex:
                 for error in ex.errors:
                     errors.add(Invalid("section %s: %s" % (cloud_name, error)))
 
@@ -675,7 +675,7 @@ class ConfigReader(object):
                         name, str.join(", ", [str(e) for e in errors.errors])))
                 else:
                     conf_values[name] = values
-            except KeyError, ex:
+            except KeyError as ex:
                 errors.add("Error in section `%s`" % cluster)
 
         # FIXME: do we really need to raise an exception if we cannot

--- a/elasticluster/main.py
+++ b/elasticluster/main.py
@@ -123,7 +123,7 @@ class ElastiCluster(cli.app.CommandLineApp):
             # directory if we can.
             try:
                 os.makedirs(self.params.storage)
-            except OSError, ex:
+            except OSError as ex:
                 sys.stderr.write("Unable to create storage directory: "
                                  "%s\n" % (str(ex)))
                 sys.exit(1)

--- a/elasticluster/providers/ansible_provider.py
+++ b/elasticluster/providers/ansible_provider.py
@@ -304,7 +304,7 @@ class AnsibleSetupProvider(AbstractSetupProvider):
                     if self._storage_path_tmp:
                         if len(os.listdir(self._storage_path)) == 0:
                             shutil.rmtree(self._storage_path)
-                except OSError, ex:
+                except OSError as ex:
                     log.warning(
                         "AnsibileProvider: Ignoring error while deleting "
                         "inventory file %s: %s", inventory_path, ex)

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -208,7 +208,7 @@ class BotoCloudProvider(AbstractCloudProvider):
                 image_id, key_name=key_name, security_groups=security_groups,
                 instance_type=flavor, user_data=image_userdata,
                 network_interfaces=interfaces)
-        except Exception, ex:
+        except Exception as ex:
             log.error("Error starting instance: %s", ex)
             if "TooManyInstances" in ex:
                 raise ClusterError(ex)
@@ -290,7 +290,7 @@ class BotoCloudProvider(AbstractCloudProvider):
         if not free_addresses:
             try:
                 address = connection.allocate_address()
-            except Exception, ex:
+            except Exception as ex:
                 log.error("Unable to allocate a public IP address to instance `%s`",
                           instance.id)
                 return None
@@ -299,7 +299,7 @@ class BotoCloudProvider(AbstractCloudProvider):
             address = free_addresses.pop()
             instance.use_ip(address)
             return address.public_ip
-        except Exception, ex:
+        except Exception as ex:
             log.error("Unable to associate IP address %s to instance `%s`",
                       address, instance.id)
             return None
@@ -395,7 +395,7 @@ class BotoCloudProvider(AbstractCloudProvider):
                             "Please specify a valid RSA key.")
 
                     connection.import_key_pair(name, key_material)
-                except Exception, ex:
+                except Exception as ex:
                     log.error(
                         "Could not import key `%s` with name `%s` to `%s`",
                         name, public_key_path, self._url)

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -247,7 +247,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 key_material = f.read()
                 try:
                     self.client.keypairs.create(name, key_material)
-                except Exception, ex:
+                except Exception as ex:
                     log.error(
                         "Could not import key `%s` with name `%s` to `%s`",
                         name, public_key_path, self._os_auth_url)

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -80,7 +80,7 @@ class AbstractCommand():
 def cluster_summary(cluster):
     try:
         frontend = cluster.get_frontend_node().name
-    except NodeNotFound, ex:
+    except NodeNotFound as ex:
         frontend = 'unknown'
         log.error("Unable to get information on the frontend node: "
                   "%s", str(ex))
@@ -173,7 +173,7 @@ class Start(AbstractCommand):
             try:
                 cluster = configurator.create_cluster(
                     cluster_template, cluster_name)
-            except ConfigurationError, e:
+            except ConfigurationError as e:
                 log.error("Starting cluster %s: %s\n" % (cluster_template, e))
                 return
 
@@ -236,7 +236,7 @@ class Stop(AbstractCommand):
             include_config_dirs=True)
         try:
             cluster = configurator.load_cluster(cluster_name)
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Stopping cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -316,7 +316,7 @@ class ResizeCluster(AbstractCommand):
         try:
             cluster = configurator.load_cluster(cluster_name)
             cluster.update()
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Listing nodes from cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -467,7 +467,7 @@ name:     %s""" % template)
                     print("%s nodes: %d" % (
                         nodekind,
                         len(cluster.nodes[nodekind])))
-            except ConfigurationError, ex:
+            except ConfigurationError as ex:
                 log.error("unable to load cluster `%s`: %s", template, ex)
 
 
@@ -504,7 +504,7 @@ class ListNodes(AbstractCommand):
             cluster = configurator.load_cluster(cluster_name)
             if self.params.update:
                 cluster.update()
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Listing nodes from cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -541,7 +541,7 @@ class SetupCluster(AbstractCommand):
         try:
             cluster = configurator.load_cluster(cluster_name)
             cluster.update()
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Setting up cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -580,7 +580,7 @@ class SshFrontend(AbstractCommand):
         try:
             cluster = configurator.load_cluster(cluster_name)
             cluster.update()
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Setting up cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -596,7 +596,7 @@ class SshFrontend(AbstractCommand):
                     ssh.close()
                 cluster.repository.save_or_update(cluster)
 
-        except NodeNotFound, ex:
+        except NodeNotFound as ex:
             log.error("Unable to connect to the frontend node: %s" % str(ex))
             sys.exit(1)
         host = frontend.connection_ip()
@@ -639,7 +639,7 @@ class SftpFrontend(AbstractCommand):
         try:
             cluster = configurator.load_cluster(cluster_name)
             cluster.update()
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Setting up cluster %s: %s\n" %
                       (cluster_name, ex))
             return
@@ -647,7 +647,7 @@ class SftpFrontend(AbstractCommand):
         try:
             cluster.ssh_to = configurator.cluster_conf[cluster.extra['template']]['cluster'].get('ssh_to', cluster.ssh_to)
             frontend = cluster.get_frontend_node()
-        except NodeNotFound, ex:
+        except NodeNotFound as ex:
             log.error("Unable to connect to the frontend node: %s" % str(ex))
             sys.exit(1)
         host = frontend.connection_ip()
@@ -688,7 +688,7 @@ class GC3PieConfig(AbstractCommand):
         cluster_name = self.params.cluster
         try:
             cluster = configurator.load_cluster(cluster_name)
-        except (ClusterNotFound, ConfigurationError), ex:
+        except (ClusterNotFound, ConfigurationError) as ex:
             log.error("Listing nodes from cluster %s: %s\n" %
                       (cluster_name, ex))
             return


### PR DESCRIPTION
Replace all instances of this python2-style syntax:

    try:
        ...
    except Exception, e:
        ...

with this python3-style syntax:

    try:
        ...
    except Exception as e:
        ...