### PR TITLE
Update the instructions for obtaining the client_id and client_secret for Google Compute Engine

### DIFF
--- a/docs/config.template
+++ b/docs/config.template
@@ -93,9 +93,9 @@
 #
 # Valid configuration keys for *google*
 # -------------------------------------
-# gce_client_id:     The API client id generated in the Google API Console
+# gce_client_id:     The API client id generated in the Google Developers Console
 #
-# gce_client_secret: The API client secret generated in the Google API Console
+# gce_client_secret: The API client secret generated in the Google Developers Console
 #
 # gce_project_id:    The project id of your Google Compute Engine project
 #
@@ -132,22 +132,28 @@
 #                      Valid values: `True`, `False`. Default is `False`
 #
 #
-# API Console
-# +++++++++++
+# Google Compute Engine users
+# +++++++++++++++++++++++++++
 #
 # To generate a client_id and client_secret to access the Google Compute
-# Engine visit the following page: https://code.google.com/apis/console/
+# Engine visit the following page:
 #
-# 1. Select the project defined as gce_project_id
-# 2. Navigate to `API Access`
-# 3. Click create another client id
-# 4. Select `Installed Application` -> `Other`
-# 5. After clicking the `Create` button you'll see your client_id and
-#    secret_key in the list of available client ids
+#   https://console.developers.google.com/project/_/apiui/credential
 #
-# **Please note**: you have to set your google username in the login
-# section below as `image_user` to be able to use Google Compute
-# Engine
+# 1. Select the project to be used for your cluster
+# 2. If a "Client ID for native application" is listed on this page,
+#    skip to step 8
+# 3. Under the OAuth section, click "Create new Client ID"
+# 4. Select "Installed Application"
+# 5. If prompted, click "Configure consent screen" and follow the
+#    instructions to set a "product name" to identify your Cloud
+#    project in the consent screen
+# 6. In the Create Client ID dialog, be sure the following are selected:
+#      Application type: Installed application
+#      Installed application type: Other
+# 7. Click the "Create Client ID" button
+# 8. You'll see your Client ID and Client secret listed under
+#    "Client ID for native application"
 #
 #
 #

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -288,9 +288,11 @@ Engine visit the following page:
 5. If prompted, click "Configure consent screen" and follow the
    instructions to set a "product name" to identify your Cloud
    project in the consent screen
-6. In the Create Client ID dialog, be sure the following are selected:
-     => Application type: Installed application
-     => Installed application type: Other
+6. In the Create Client ID dialog, be sure the following are selected::
+
+    Application type: Installed application
+    Installed application type: Other
+  
 7. Click the "Create Client ID" button
 8. You'll see your Client ID and Client secret listed under
    "Client ID for native application"

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -164,11 +164,11 @@ Valid configuration keys for `google`
 
 ``gce_client_id``
 
-    The API client id generated in the Google API Console
+    The API client id generated in the Google Developers Console
 
 ``gce_client_secret``
 
-    The API client secret generated in the Google API Console
+    The API client secret generated in the Google Developers Console
 
 ``gce_project_id``
 
@@ -276,17 +276,24 @@ configuration file:
 Google Compute Engine users
 +++++++++++++++++++++++++++
 To generate a client_id and client_secret to access the Google Compute
-Engine visit the following page: https://code.google.com/apis/console/
+Engine visit the following page:
 
-1. Select the project defined as gce_project_id
-2. Navigate to `API Access`
-3. Click create another client id
-4. Select `Installed Application` -> `Other`
-5. After clicking the `Create` button you'll see your client_id and
-   secret_key in the list of available client ids
+  https://console.developers.google.com/project/_/apiui/credential
 
-**Please note**: you have to set your google username in the login section  below as image_user to be able to use Google Compute Engine
-
+1. Select the project to be used for your cluster
+2. If a "Client ID for native application" is listed on this page,
+   skip to step 8
+3. Under the OAuth section, click "Create new Client ID"
+4. Select "Installed Application"
+5. If prompted, click "Configure consent screen" and follow the
+   instructions to set a "product name" to identify your Cloud
+   project in the consent screen
+6. In the Create Client ID dialog, be sure the following are selected:
+     *Application type*: Installed application
+     *Installed application type*: Other
+7. Click the "Create Client ID" button
+8. You'll see your Client ID and Client secret listed under
+   "Client ID for native application"
 
 Login Section
 ===============

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -289,8 +289,8 @@ Engine visit the following page:
    instructions to set a "product name" to identify your Cloud
    project in the consent screen
 6. In the Create Client ID dialog, be sure the following are selected:
-     *Application type*: Installed application
-     *Installed application type*: Other
+     => Application type: Installed application
+     => Installed application type: Other
 7. Click the "Create Client ID" button
 8. You'll see your Client ID and Client secret listed under
    "Client ID for native application"

--- a/docs/html/configure.html
+++ b/docs/html/configure.html
@@ -180,10 +180,10 @@ instance doesn&#8217;t get one automatically.</div></blockquote>
 <h3>Valid configuration keys for <cite>google</cite><a class="headerlink" href="#valid-configuration-keys-for-google" title="Permalink to this headline">¶</a></h3>
 <p><tt class="docutils literal"><span class="pre">gce_client_id</span></tt></p>
 <blockquote>
-<div>The API client id generated in the Google API Console</div></blockquote>
+<div>The API client id generated in the Google Developers Console</div></blockquote>
 <p><tt class="docutils literal"><span class="pre">gce_client_secret</span></tt></p>
 <blockquote>
-<div>The API client secret generated in the Google API Console</div></blockquote>
+<div>The API client secret generated in the Google Developers Console</div></blockquote>
 <p><tt class="docutils literal"><span class="pre">gce_project_id</span></tt></p>
 <blockquote>
 <div>The project id of your Google Compute Engine project</div></blockquote>
@@ -283,16 +283,19 @@ configuration file:</p>
 <div class="section" id="google-compute-engine-users">
 <h4>Google Compute Engine users<a class="headerlink" href="#google-compute-engine-users" title="Permalink to this headline">¶</a></h4>
 <p>To generate a client_id and client_secret to access the Google Compute
-Engine visit the following page: <a class="reference external" href="https://code.google.com/apis/console/">https://code.google.com/apis/console/</a></p>
+Engine visit the following page: <a class="reference external" href="https://console.developers.google.com/project/_/apiui/credential" target=_blank>https://console.developers.google.com/project/_/apiui/credential</a></p>
 <ol class="arabic simple">
-<li>Select the project defined as gce_project_id</li>
-<li>Navigate to <cite>API Access</cite></li>
-<li>Click create another client id</li>
-<li>Select <cite>Installed Application</cite> -&gt; <cite>Other</cite></li>
-<li>After clicking the <cite>Create</cite> button you&#8217;ll see your client_id and
-secret_key in the list of available client ids</li>
+<li>Select the project to be used for your cluster</li>
+<li>If a "Client ID for native application" is listed on this page, skip to step 8</li>
+<li>Under the OAuth section, click "Create new Client ID"</li>
+<li>Select "Installed Application"</li>
+<li>If prompted, click "Configure consent screen" and follow the instructions to set a "product name" to identify your Cloud project in the consent screen</li>
+<li>In the Create Client ID dialog, be sure the following are selected:<br>
+&nbsp;&nbsp;<b>Application type</b>: Installed application<br>
+&nbsp;&nbsp;<b>Installed application type</b>: Other</li>
+<li>Click the "Create Client ID" button</li>
+<li>You'll see your Client ID and Client secret listed under "Client ID for native application"</li>
 </ol>
-<p><strong>Please note</strong>: you have to set your google username in the login section  below as image_user to be able to use Google Compute Engine</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Re-submit of #157 from non-master branch.

(Also removed the note in the Google-specific section regarding image_user as it is called out in the generic "Mandatory configuration keys".)