### PR TITLE
Add support for nonstandard ssh ports

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -38,6 +38,9 @@ from elasticluster.exceptions import TimeoutError, NodeNotFound, \
     InstanceError, ClusterError
 from elasticluster.repository import MemRepository
 
+SSH_PORT = 22
+IPV6_RE = re.compile('\[([a-f:A-F0-9]*[%[0-z]+]?)\](?::(\d+))?')
+
 class IgnorePolicy(paramiko.MissingHostKeyPolicy):
     def missing_host_key(self, client, hostname, key):
         log.info('Ignoring unknown %s host key for %s: %s' %
@@ -939,11 +942,26 @@ class Node(Struct):
             try:
                 log.debug("Trying to connect to host %s (%s)",
                           self.name, ip)
-                ssh.connect(ip,
+                # check for nonstandard port, either IPv4 or IPv6
+                addr = ip
+                port = SSH_PORT
+                if ':' in ip:
+                    match = IPV6_RE.match(ip)
+                    if match:
+                        addr = match.groups()[0]
+                        port = match.groups()[1]
+                    else:
+                        addr, _, port = ip.partition(':')
+                # if port not specified, will default to SSH_PORT (22)
+                if port:
+                    port = int(port)
+
+                ssh.connect(addr,
                             username=self.image_user,
                             allow_agent=True,
                             key_filename=self.user_key_private,
-                            timeout=Node.connection_timeout)
+                            timeout=Node.connection_timeout,
+                            port=port)
                 log.debug("Connection to %s succeded!", ip)
                 if ip != self.preferred_ip:
                     log.debug("Setting `preferred_ip` to %s", ip)

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -27,11 +27,15 @@ import os
 import shutil
 import sys
 import tempfile
+import re
 
 # Elasticluster imports
 from elasticluster import get_configurator, log
 from elasticluster.exceptions import ClusterNotFound, ConfigurationError, \
     ImageError, SecurityGroupError, NodeNotFound, ClusterError
+
+SSH_PORT = 22
+IPV6_RE = re.compile('\[([a-f:A-F0-9]*[%[0-z]+]?)\](?::(\d+))?')
 
 def ask_confirmation(msg):
     """Ask for confirmation. Returns True or False accordingly"""
@@ -697,6 +701,18 @@ class SshFrontend(AbstractCommand):
             log.error("Unable to connect to the frontend node: %s" % str(ex))
             sys.exit(1)
         host = frontend.connection_ip()
+
+        # check for nonstandard port, either IPv4 or IPv6
+        addr = host
+        port = str(SSH_PORT)
+        if ':' in host:
+            match = IPV6_RE.match(host)
+            if match:
+                addr = match.groups()[0]
+                port = match.groups()[1]
+            else:
+                addr, _, port = host.partition(':')
+
         username = frontend.image_user
         knownhostsfile = cluster.known_hosts_file if cluster.known_hosts_file \
                          else '/dev/null'
@@ -704,7 +720,8 @@ class SshFrontend(AbstractCommand):
                        "-i", frontend.user_key_private,
                        "-o", "UserKnownHostsFile=%s" % knownhostsfile,
                        "-o", "StrictHostKeyChecking=yes",
-                       '%s@%s' % (username, host)]
+                       "-p", port,
+                       '%s@%s' % (username, addr)]
         ssh_cmdline.extend(self.params.ssh_args)
         log.debug("Running command `%s`" % str.join(' ', ssh_cmdline))
         os.execlp("ssh", *ssh_cmdline)


### PR DESCRIPTION
This is PR #1 of 2 for adding Microsoft Azure support to elasticluster.

The purpose of this PR is to add support for nonstandard ssh ports to elasticluster (as a generic
feature, independent of Azure). 

The second PR, coming shortly, will be to add the actual Azure cloud provider.

Why this first PR is needed: when Azure creates a cluster, all the virtual machines 
have the same public IP, which is the address of a load balancer. Each of the VMs will 
have its own ssh port on the load balancer, which the load balancer in turn maps to port 
22 on the VM. So we need to allow each VM to return an IP:port pair which elasticluster 
will use to contact that VM.

Changes: if the get_ips() method of the cloud provider returns an address of the 
form address:port, elasticluster will: 

1. recognize that a port number has been provided;

2. use that port when it connects to the VM using Paramiko; and

3. in the Ansible inventory file, omit the port number from the host address, but 
specify it with the ansible_ssh_port variable.

Both IPv4 and IPv6 representations of addresses, with or without port numbers, are handled correctly.

In cases where the cloud provider doesn't return a port number (i.e. any cloud provider to date
other than Azure), both elasticluster and Ansible should work exactly as before.

This will prepare elasticluster to work with a cloud provider that uses nonstandard 
ssh ports and which may host multiple VMs on the same public IP address.

(Note: Azure does support something called "Public IPs", by which a VM can be exposed 
at its own internet IP address with ssh on port 22. However, this feature is presently 
only enabled for a maximum of 5 VMs per subscription, so it isn't very useful.)

The Azure cloud provider itself is completed and tested, and a second PR for that will follow soon.