### PR TITLE
For "resize" command, pass the "extra" fields to cluster.add_node

### DIFF
--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -215,6 +215,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        instance_name=None,
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
+                       scheduling=None,
                        **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
@@ -230,6 +231,8 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str username: username for the given ssh key, default None
 
         :param str instance_name: name of the instance
+
+        :param str scheduling: scheduling option to use for the instance ("preemptible")
 
         :return: str - instance id of the started instance
         """
@@ -269,6 +272,16 @@ class GoogleCloudProvider(AbstractCloudProvider):
             image_url = '%s%s/global/images/%s' % (
                 GCE_URL, os_cloud, image_id)
 
+        scheduling_option = {}
+        if scheduling:
+          if scheduling == 'preemptible':
+            scheduling_option = {
+              'preemptible': True
+            }
+          else:
+            log.error("Unknown scheduling option: '%s'" % scheduling)
+            raise InstanceError("Unknown scheduling option: '%s'" % scheduling)
+
         # construct the request body
         if instance_name is None:
             instance_name = 'elasticluster-%s' % uuid.uuid4()
@@ -278,6 +291,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
         instance = {
             'name': instance_name,
             'machineType': machine_type_url,
+            'scheduling': scheduling_option,
             'disks': [{
                 'autoDelete': 'true',
                 'boot': 'true',

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -215,7 +215,6 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        instance_name=None,
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
-                       scheduling=None,
                        **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
@@ -231,8 +230,6 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str username: username for the given ssh key, default None
 
         :param str instance_name: name of the instance
-
-        :param str scheduling: scheduling option to use for the instance ("preemptible")
 
         :return: str - instance id of the started instance
         """
@@ -272,16 +269,6 @@ class GoogleCloudProvider(AbstractCloudProvider):
             image_url = '%s%s/global/images/%s' % (
                 GCE_URL, os_cloud, image_id)
 
-        scheduling_option = {}
-        if scheduling:
-          if scheduling == 'preemptible':
-            scheduling_option = {
-              'preemptible': True
-            }
-          else:
-            log.error("Unknown scheduling option: '%s'" % scheduling)
-            raise InstanceError("Unknown scheduling option: '%s'" % scheduling)
-
         # construct the request body
         if instance_name is None:
             instance_name = 'elasticluster-%s' % uuid.uuid4()
@@ -291,7 +278,6 @@ class GoogleCloudProvider(AbstractCloudProvider):
         instance = {
             'name': instance_name,
             'machineType': machine_type_url,
-            'scheduling': scheduling_option,
             'disks': [{
                 'autoDelete': 'true',
                 'boot': 'true',

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -245,7 +245,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
             image_url = image_id
         else:
             # The image names and full resource URLs for several Google-
-            # provided images (debian, centos, etc.) follows a consistent
+            # provided images (debian, centos, etc.) follow a consistent
             # pattern, and so elasticluster supports a short-hand of just
             # an image name, such as
             #   "debian-7-wheezy-v20150526".
@@ -258,14 +258,12 @@ class GoogleCloudProvider(AbstractCloudProvider):
             #   containter-vm    -> google-containers
             if image_id.startswith('container-vm-'):
               os_cloud = 'google-containers'
+            elif image_id.startswith('backports-debian-'):
+              os_cloud = 'debian-cloud'
+            elif image_id.startswith('ubuntu-'):
+              os_cloud = 'ubuntu-os-cloud'
             else:
-              if image_id.startswith('backports-'):
-                os = image_id.split("-")[1]
-              elif image_id.startswith('ubuntu-'):
-                os = 'ubuntu-os'
-              else:
-                os = image_id.split("-")[0]
- 
+              os = image_id.split("-")[0]
               os_cloud = "%s-cloud" % os
 
             image_url = '%s%s/global/images/%s' % (

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -244,8 +244,30 @@ class GoogleCloudProvider(AbstractCloudProvider):
         if image_id.startswith('http://') or image_id.startswith('https://'):
             image_url = image_id
         else:
-            os = image_id.split("-")[0]
-            os_cloud = "%s-cloud" % os
+            # The image names and full resource URLs for several Google-
+            # provided images (debian, centos, etc.) follows a consistent
+            # pattern, and so elasticluster supports a short-hand of just
+            # an image name, such as
+            #   "debian-7-wheezy-v20150526".
+            # The cloud project in this case is then "debian-cloud".
+            #
+            # Several images do not follow this convention, and so are
+            # special-cased here:
+            #   backports-debian -> debian-cloud
+            #   ubuntu           -> ubuntu-os-cloud
+            #   containter-vm    -> google-containers
+            if image_id.startswith('container-vm-'):
+              os_cloud = 'google-containers'
+            else:
+              if image_id.startswith('backports-'):
+                os = image_id.split("-")[1]
+              elif image_id.startswith('ubuntu-'):
+                os = 'ubuntu-os'
+              else:
+                os = image_id.split("-")[0]
+ 
+              os_cloud = "%s-cloud" % os
+
             image_url = '%s%s/global/images/%s' % (
                 GCE_URL, os_cloud, image_id)
 

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -358,19 +358,29 @@ class ResizeCluster(AbstractCommand):
                                      sample_node.image_user,
                                      sample_node.flavor,
                                      sample_node.security_group,
-                                     image_userdata=sample_node.image_userdata)
+                                     image_userdata=sample_node.image_userdata,
+                                     **sample_node.extra)
             else:
                 conf = configurator.cluster_conf[template]
                 conf_kind = conf['nodes'][grp]
+
+                image_user = conf['login']['image_user']
+                userdata = conf_kind.get('image_userdata', '')
+
+                extra = conf_kind.copy()
+                extra.pop('image_id', None)
+                extra.pop('flavor', None)
+                extra.pop('security_group', None)
+                extra.pop('image_userdata', None)
+
                 for i in range(self.params.nodes_to_add[grp]):
-                    image_user = conf['login']['image_user']
-                    userdata = conf_kind.get('image_userdata', '')
                     cluster.add_node(grp,
                                      conf_kind['image_id'],
                                      image_user,
                                      conf_kind['flavor'],
                                      conf_kind['security_group'],
-                                     image_userdata=userdata)
+                                     image_userdata=userdata,
+                                     **extra)
 
         for grp in self.params.nodes_to_remove:
             n_to_rm = self.params.nodes_to_remove[grp]


### PR DESCRIPTION
I fixed this for both the case where the first node is used as a template as well as the case where an explicit template is specified. I moved two lines out of the "for" loop:

    image_user = conf['login']['image_user']
    userdata = conf_kind.get('image_userdata', '')

as best as I can tell, they don't need to be set with each iteration.

This is intended to fix https://github.com/gc3-uzh-ch/elasticluster/issues/169.