### PR TITLE
Remove explicit pbr version number (0.11.0).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ required_packages = [
     'boto',
     # OpenStack clouds
     'python-novaclient',
-    'pbr==0.11.0',
+    'pbr',
     # GCE cloud
     'google-api-python-client',
     'python-gflags',


### PR DESCRIPTION
The explicit version causes install errors due to recent changes
to the oslo package:

Install fails: error: pbr 0.11.0 is installed but pbr<2.0,>=1.3 is required by set(['oslo.utils'])

This fixes https://github.com/gc3-uzh-ch/elasticluster/issues/174