### PR TITLE
Add support for Google Compute Engine "Preemptible VMs"

### DIFF
--- a/docs/config.template
+++ b/docs/config.template
@@ -483,6 +483,10 @@ worker_groups=ipython_engine
 #                 Only supported when the cloud provider is google.
 #                 Values are specified in gigabytes.
 #                 Default value is 10.
+#
+# scheduling: Define the type of instance scheduling.
+#             Only supported when the cloud provider is google.
+#             Only supported value is preemptible.
 
 # Some (working) examples:
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -604,6 +604,11 @@ Optional configuration keys
     Values are specified in gigabytes.
     Default value is 10.
 
+``scheduling``
+    Define the type of instance scheduling.
+    Only supported when the cloud provider is `google`.
+    Only supported value is `preemptible`.
+
 Examples
 --------
 

--- a/docs/html/configure.html
+++ b/docs/html/configure.html
@@ -564,6 +564,12 @@ Default value is <em>pd-standard</em>.
 Only supported when the cloud provider is <cite>google</cite>.
 Value is specified in gigabytes.  Default value is 10.
 </div></blockquote>
+<p><tt class="docutils literal"><span class="pre">scheduling</span></tt></p>
+<blockquote>
+<div>Define the type of instance scheduling.
+Only supported when the cloud provider is <cite>google</cite>.
+Only supported value is <cite>preemptible</cite>.
+</div></blockquote>
 </div>
 <div class="section" id="id5">
 <h3>Examples<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -982,11 +982,12 @@ class Node(Struct):
 
         :return: str - representaion of a node in pretty print
         """
+        ips = ', '.join(ip for ip in self.ips if ip)
         return """%s
 connection IP: %s
 IPs:    %s
 instance id:   %s
-instance flavor: %s""" % (self.name, self.preferred_ip, str.join(', ', self.ips),
+instance flavor: %s""" % (self.name, self.preferred_ip, ips,
                           self.instance_id, self.flavor)
 
 

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -394,7 +394,7 @@ class Cluster(Struct):
         else:
             try:
                 node.start()
-                log.info("_start_node: node has been started")
+                log.info("_start_node: node '%s' has been started" % node.name)
                 return True
             except Exception as e:
                 log.error("could not start node `%s` for reason "
@@ -954,6 +954,9 @@ class Node(Struct):
             except socket.error as ex:
                 log.debug("Host %s (%s) not reachable: %s.",
                           self.name, ip, ex)
+            except paramiko.BadHostKeyException as ex:
+                print "Invalid host key: host %s (%s); check keyfile: %s" % (
+                      self.name, ip, keyfile)
             except paramiko.SSHException as ex:
                 log.debug("Ignoring error %s connecting to %s",
                           str(ex), self.name)

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -973,8 +973,9 @@ class Node(Struct):
         return self.ips[:]
 
     def __str__(self):
+        ips = ', '.join(ip for ip in self.ips if ip)
         return "name=`%s`, id=`%s`, ips=%s, "\
-            "connection_ip=`%s`" % (self.name, self.instance_id, str.join(', ', self.ips),
+            "connection_ip=`%s`" % (self.name, self.instance_id, ips,
                                     self.preferred_ip)
 
     def pprint(self):

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -215,6 +215,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        instance_name=None,
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
+                       scheduling=None,
                        **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
@@ -230,6 +231,8 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str username: username for the given ssh key, default None
 
         :param str instance_name: name of the instance
+
+        :param str scheduling: scheduling option to use for the instance ("preemptible")
 
         :return: str - instance id of the started instance
         """
@@ -269,6 +272,16 @@ class GoogleCloudProvider(AbstractCloudProvider):
             image_url = '%s%s/global/images/%s' % (
                 GCE_URL, os_cloud, image_id)
 
+        scheduling_option = {}
+        if scheduling:
+          if scheduling == 'preemptible':
+            scheduling_option = {
+              'preemptible': True
+            }
+          else:
+            log.error("Unknown scheduling option: '%s'" % scheduling)
+            raise InstanceError("Unknown scheduling option: '%s'" % scheduling)
+
         # construct the request body
         if instance_name is None:
             instance_name = 'elasticluster-%s' % uuid.uuid4()
@@ -278,6 +291,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
         instance = {
             'name': instance_name,
             'machineType': machine_type_url,
+            'scheduling': scheduling_option,
             'disks': [{
                 'autoDelete': 'true',
                 'boot': 'true',

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -405,7 +405,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
             if response and response['status'] == 'TERMINATED':
               log.info("node '%s' state is '%s'; no IP address(es)" %
                        (instance_id, "TERMINATED"))
-              return [None, None]
+              return [None]
 
             if response and "networkInterfaces" in response:
                 interfaces = response['networkInterfaces']

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -279,7 +279,6 @@ class GoogleCloudProvider(AbstractCloudProvider):
               'preemptible': True
             }
           else:
-            log.error("Unknown scheduling option: '%s'" % scheduling)
             raise InstanceError("Unknown scheduling option: '%s'" % scheduling)
 
         # construct the request body

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -393,6 +393,14 @@ class GoogleCloudProvider(AbstractCloudProvider):
             response = self._execute_request(request)
             ip_private = None
             ip_public = None
+
+            # If the instance is in status TERMINATED, then there will be
+            # no IP addresses.
+            if response and response['status'] == 'TERMINATED':
+              log.info("node '%s' state is '%s'; no IP address(es)" %
+                       (instance_id, "TERMINATED"))
+              return [None, None]
+
             if response and "networkInterfaces" in response:
                 interfaces = response['networkInterfaces']
                 if interfaces:

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -344,6 +344,10 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str instance_id: instance identifier
         :raises: `InstanceError` if instance can not be stopped
         """
+        if not instance_id:
+          log.info("Instance to stop has no instance id")
+          return
+
         gce = self._connect()
 
         try:
@@ -385,6 +389,9 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :return: list (ips)
         :raises: InstanceError if the ip could not be retrieved.
         """
+        if not instance_id:
+          raise InstanceError("could not retrieve the ip address for node: "
+                              "no associated instance id")
         gce = self._connect()
         instances = gce.instances()
         try:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ required_packages = [
     'boto',
     # OpenStack clouds
     'python-novaclient',
-    'pbr==0.11.0',
+    'pbr',
     # GCE cloud
     'google-api-python-client',
     'python-gflags',


### PR DESCRIPTION
Details on preemptible VMs can be found here:

    https://cloud.google.com/compute/docs/instances/preemptible

The technical bits that are important for Elasticluster are that VMs can go from a RUNNING state to a TERMINATED state. When they are TERMINATED, they will have no IP address.

This PR:

* accepts configuration to mark nodes as preemptible ("scheduling=preemptible")
* handles the TERMINATED state, and returns an empty IP address
* updates a few places in the code that assumed non-empty IP address lists