### PR TITLE
Add support for Compute Engine instance tags

### DIFF
--- a/docs/config.template
+++ b/docs/config.template
@@ -483,6 +483,11 @@ worker_groups=ipython_engine
 #                 Only supported when the cloud provider is google.
 #                 Values are specified in gigabytes.
 #                 Default value is 10.
+#
+# tags: Comma-separated list of instance tags.
+#                 Only supported when the cloud provider is google.
+#
+
 
 # Some (working) examples:
 

--- a/docs/config.template
+++ b/docs/config.template
@@ -485,7 +485,7 @@ worker_groups=ipython_engine
 #                 Default value is 10.
 #
 # tags: Comma-separated list of instance tags.
-#                 Only supported when the cloud provider is google.
+#       Only supported when the cloud provider is google.
 #
 
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -604,6 +604,10 @@ Optional configuration keys
     Values are specified in gigabytes.
     Default value is 10.
 
+``tags``
+    Comma-separated list of instance tags.
+    Only supported when the cloud provider is `google`.
+
 Examples
 --------
 

--- a/docs/html/configure.html
+++ b/docs/html/configure.html
@@ -564,6 +564,11 @@ Default value is <em>pd-standard</em>.
 Only supported when the cloud provider is <cite>google</cite>.
 Value is specified in gigabytes.  Default value is 10.
 </div></blockquote>
+<p><tt class="docutils literal"><span class="pre">tags</span></tt></p>
+<blockquote>
+<div>Comma-separated list of instance tags.
+Only supported when the cloud provider is <cite>google</cite>.
+</div></blockquote>
 </div>
 <div class="section" id="id5">
 <h3>Examples<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -215,6 +215,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        instance_name=None,
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
+                       tags=None,
                        **kwargs):
         """Starts a new instance with the given properties and returns
         the instance id.
@@ -230,6 +231,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
         :param str username: username for the given ssh key, default None
 
         :param str instance_name: name of the instance
+        :param str tags: comma-separated list of "tags" to label the instance
 
         :return: str - instance id of the started instance
         """
@@ -278,6 +280,9 @@ class GoogleCloudProvider(AbstractCloudProvider):
         instance = {
             'name': instance_name,
             'machineType': machine_type_url,
+            'tags': {
+              'items': tags.split(',') if tags else None
+            },
             'disks': [{
                 'autoDelete': 'true',
                 'boot': 'true',


### PR DESCRIPTION
Add support for Compute Engine instance tags
 (https://cloud.google.com/compute/docs/reference/latest/instances#tags)