### PR TITLE
Update cluster.update() to try to set the node's preferred_ip

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -769,6 +769,14 @@ class Cluster(Struct):
         for node in self.get_all_nodes():
             try:
                 node.update_ips()
+
+                # If we previously did not have a preferred_ip or the
+                # preferred_ip is not in the current list, then try to connect
+                # to one of the node ips and update the preferred_ip.
+                if node.ips and \
+                   not (node.preferred_ip and \
+                        node.preferred_ip in node.ips):
+                  node.connect()
             except InstanceError as ex:
                 log.warning("Ignoring error updating information on node %s: %s",
                           node, str(ex))

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -361,7 +361,15 @@ class GoogleCloudProvider(AbstractCloudProvider):
                                         instance=instance_id, zone=self._zone)
             response = self._execute_request(request)
             self._check_response(response)
-        except (HttpError, CloudProviderError) as e:
+        except HttpError as e:
+            # If the instance does not exist, we can a 404 - just log it, and
+            # return without exception so the caller can remove the reference.
+            if e.resp.status == 404:
+              log.warning("Instance to stop `%s` was not found" % instance_id)
+            else:
+              raise InstanceError("Could not stop instance `%s`: `%s`"
+                                  % (instance_id, e))
+        except CloudProviderError as e:
             raise InstanceError("Could not stop instance `%s`: `%s`"
                                 % (instance_id, e))
 

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -416,9 +416,9 @@ class GoogleCloudProvider(AbstractCloudProvider):
 
             # If the instance is in status TERMINATED, then there will be
             # no IP addresses.
-            if response and response['status'] == 'TERMINATED':
+            if response and response['status'] in ('STOPPING', 'TERMINATED'):
               log.info("node '%s' state is '%s'; no IP address(es)" %
-                       (instance_id, "TERMINATED"))
+                       (instance_id, response['status']))
               return [None]
 
             if response and "networkInterfaces" in response:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -633,6 +633,8 @@ class SetupCluster(AbstractCommand):
                                         storage_path=self.params.storage,
                                         include_config_dirs=True)
         cluster_name = self.params.cluster
+
+        print("Updating cluster `%s`..." % cluster_name)
         try:
             cluster = configurator.load_cluster(cluster_name)
             cluster.update()


### PR DESCRIPTION
after calling node.update_ips()

I have occasionally had nodes in the saved nodes list which had no IP addresses saved.
Running "elasticluster setup" would call node.update_ips(), but then didn't try to "connect()" before handing the node to ansible (which then had no IP address to connect to).