### PR TITLE
Fix Ansible version requirement for CentOS6 and 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ from setuptools import setup, find_packages
 required_packages = [
     'PyCLI',
     'paramiko',
-    'ansible~=1.9.4',
+    'ansible>=1.9.4, <2.0.0',
     'voluptuous>=0.8.2',
     'configobj',
     'coloredlogs',


### PR DESCRIPTION
The version of `setuptools` is too old to cope with the `~=` notation.

This PR uses an uglier version that should be compatible with older `setuptools` installations.