### PR TITLE
Ansible 2.0 for develop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def ansible_pb_files():
 required_packages = [
     'PyCLI',
     'paramiko',
-    'ansible>=1.9.4, <2.0.0',
+    'ansible>=2.0.0',
     'voluptuous>=0.8.2',
     'configobj',
     'coloredlogs',


### PR DESCRIPTION
Using Ansible 2.0 and above should remove the need to fix `sudoers` on CentOS7, but without this commit, the `develop` branch will complain that Ansible 2.0 is too new.