### PR TITLE
Make ec2 access_key and secrets optional

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -418,8 +418,8 @@ class ConfigValidator(object):
 
         cloud_schema_ec2 = {"provider": 'ec2_boto',
                             "ec2_url": Url(str),
-                            "ec2_access_key": All(str, Length(min=1)),
-                            "ec2_secret_key": All(str, Length(min=1)),
+                            Optional("ec2_access_key"): All(str, Length(min=1)),
+                            Optional("ec2_secret_key"): All(str, Length(min=1)),
                             "ec2_region": All(str, Length(min=1)),
                             Optional("request_floating_ip"): Boolean(str),
                             Optional("vpc"): All(str, Length(min=1)),
@@ -560,8 +560,8 @@ class ConfigReader(object):
             "cloud": Schema(
                 {"provider": Any('ec2_boto', 'google', 'openstack'),
                  "ec2_url": Url(str),
-                 "ec2_access_key": All(str, Length(min=1)),
-                 "ec2_secret_key": All(str, Length(min=1)),
+                 Optional("ec2_access_key"): All(str, Length(min=1)),
+                 Optional("ec2_secret_key"): All(str, Length(min=1)),
                  "ec2_region": All(str, Length(min=1)),
                  "auth_url": All(str, Length(min=1)),
                  "username": All(str, Length(min=1)),

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -53,8 +53,9 @@ class BotoCloudProvider(AbstractCloudProvider):
     """
     __node_start_lock = threading.Lock()  # lock used for node startup
 
-    def __init__(self, ec2_url, ec2_region, ec2_access_key, ec2_secret_key,
-                 vpc=None, storage_path=None, request_floating_ip=False):
+    def __init__(self, ec2_url, ec2_region, ec2_access_key=None,
+                 ec2_secret_key=None, vpc=None, storage_path=None,
+                 request_floating_ip=False):
         self._url = ec2_url
         self._region_name = ec2_region
         self._access_key = ec2_access_key


### PR DESCRIPTION
This allows for boto credentials to be passed via iam roles when running on ec2 or via a .aws/credentials file from the awscli tool rather than being explicitly placed in a configuration file.