### PR TITLE
SLURM service start fix

### DIFF
--- a/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
+++ b/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
@@ -131,7 +131,7 @@ Waittime=0
 ControlMachine={{SLURM_MASTER_HOST}}
 ControlAddr={{SLURM_MASTER_ADDR}}
 
-SlurmctldPidFile=/var/run/slurm/slurmctld.pid
+SlurmctldPidFile=/var/run/slurmctld.pid
 SlurmctldPort=6817
 SlurmctldTimeout=300
 

--- a/elasticluster/share/playbooks/roles/slurm-master/templates/slurmdbd.conf.j2
+++ b/elasticluster/share/playbooks/roles/slurm-master/templates/slurmdbd.conf.j2
@@ -13,7 +13,7 @@
 # see: http://slurm.schedmd.com/slurmdbd.conf.html
 
 # how to run the SLURM DBD process
-PidFile=/var/run/slurm/slurmdbd.pid
+PidFile=/var/run/slurmdbd.pid
 LogFile=/var/log/slurm/slurmdbd.log
 DebugLevel=error
 


### PR DESCRIPTION
Synchronise the PID location in the config files with the systemd unit file
