### PR TITLE
Documentation: Use ec2_boto consistently to avoid confusion

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -105,7 +105,7 @@ provider is done in the `cluster` section (see later).
 Currently three cloud providers are available:
 
 - openstack: supports OpenStack cloud
-- boto: supports Amazon EC2 and compatible cloud
+- ec2_boto: supports Amazon EC2 and compatible cloud
 - google: supports Google Compute Engine
 
 Therefore the following configuration option needs to be set in the cloud
@@ -118,7 +118,7 @@ section:
 
 
 
-Valid configuration keys for `boto`
+Valid configuration keys for `ec2_boto`
 -----------------------------------
 
 ``ec2_url``


### PR DESCRIPTION
Both "boto" and "ec2_boto" are used inconsistently in the documentation and lead to some debugging because the wrong key was used (and accepted) in the config file. This patch makes the use consistent by changing all occurrences of "boto" to "ec2_boto".