### PR TITLE
Fix warning from setup.py by stripping white-space from version.txt content

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="elasticluster",
-    version=read_whole_file("version.txt"),
+    version=read_whole_file("version.txt").strip(),
     description="A command line tool to create, manage and setup computing clusters hosted on a public or private cloud infrastructure.",
     long_description=read_whole_file('README.rst'),
     author="Services and Support for Science IT, University of Zurich",


### PR DESCRIPTION
I'm (almost) sorry for this trivial patch but the warning when running `setup.py` started to annoy me. ;-)

Best,

Manuel
