### PR TITLE
Wait until OpenStack instance provisioning is finished

### DIFF
--- a/tests/providers/test_openstack.py
+++ b/tests/providers/test_openstack.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+from mock import MagicMock
+
+from elasticluster import OpenStackCloudProvider
+
+
+class TestOpenStackCloudProvider(TestCase):
+    @staticmethod
+    def _create_provider():
+        return OpenStackCloudProvider('irrelevant', 'irrelevant', 'irrelevant', 'https://example.com')
+
+    def test_that_is_instance_running_returns_true_if_instance_in_active_state_and_cloud_init_finished(self):
+        provider = self._create_provider()
+        instance = MagicMock()
+        instance.status = 'ACTIVE'
+        provider._load_instance = MagicMock(return_value=instance)
+        provider.is_cloud_init_finished = MagicMock(return_value=True)
+
+        assert provider.is_instance_running('some_id')
+
+    def test_that_is_instance_running_returns_false_if_instance_not_in_active_state_ignoring_cloud_init(self):
+        # Given an OpenStack provider with a fake instance claiming not being active
+        provider = self._create_provider()
+        instance = MagicMock()
+        instance.status = 'something other than ACTIVE'
+        provider._load_instance = MagicMock(return_value=instance)
+        # Then
+        assert not provider.is_instance_running('some_id')
+
+    def test_is_cloud_init_finished_when_entry_found_then_return_true(self):
+        # Given the console output has a matching line
+        provider = self._create_provider()
+        provider.get_console_output = MagicMock(
+            return_value="[   14.632794] cloud-init[2077]: Cloud-init v. 0.7.5 finished at Tue, 07 Jun 2016 15:10:35 +0000. Datasource DataSourceOpenStack [net,ver=2].  Up 14.62 seconds")
+        # Then
+        assert provider.is_cloud_init_finished('irrelevant')
+
+    def test_is_cloud_init_finished_when_entry_not_found_then_return_false(self):
+        # Given the console output has no matching lines
+        provider = self._create_provider()
+        provider.get_console_output = MagicMock(return_value="not what is expected\nalso not was is expected")
+        # Then
+        assert not provider.is_cloud_init_finished('irrelevant')


### PR DESCRIPTION
A small change (and tests) that make ElastiCluster wait until OpenStack instances have finished setting up. It assumes that `cloud-init` is used which should be the case on all OpenStack instances. That said, I'm not sure how much we should rely on it. (But everyone I asked said it is a reasonable assumption to expect `cloud-init` to be present.)