### PR TITLE
(docs): rename slurm_clients to slurm_workers

### DIFF
--- a/docs/api/elasticluster.rst
+++ b/docs/api/elasticluster.rst
@@ -144,7 +144,7 @@ types on other cloud providers can be setup accordingly.
     # Initialising the setup provider needs a little more preparation:
     # the groups dictionary specifies the kind of nodes used for this cluster.
     # In this case we want a frontend and a compute kind. The frontend node
-    # (s) will be setup as slurm_master, the compute node(s) as slurm_clients.
+    # (s) will be setup as slurm_master, the compute node(s) as slurm_workers.
     # This corresponds to the documentation of the ansible playbooks
     # provided with elasticluster. The kind of the node is a name specified
     # by the user. This name will be used to set a new hostname on the
@@ -152,7 +152,7 @@ types on other cloud providers can be setup accordingly.
     # groups['kind'] = ['andible_group1', 'ansible_group2']
     groups = dict()
     groups['frontend'] = ['slurm_master']
-    groups['compute'] = ['slurm_clients']
+    groups['compute'] = ['slurm_workers']
 
     setup_provider = elasticluster.AnsibleSetupProvider(groups)
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -425,7 +425,7 @@ The following configuration keys are only valid if `provider` is
     ``slurm_master``
         configure this machine as slurm masternode
 
-    ``slurm_clients``
+    ``slurm_workers``
         compute nodes of a slurm cluster
 
     ``ganglia_master``
@@ -439,7 +439,7 @@ The following configuration keys are only valid if `provider` is
     combinations make sense. A common setup is, for instance::
 
         frontend_groups=slurm_master,ganglia_master,ganglia_monitor
-        compute_groups=slurm_clients,ganglia_monitor
+        compute_groups=slurm_workers,ganglia_monitor
 
     This will configure the frontend node as slurm master and ganglia
     frontend, and the compute nodes as clients for both slurm and
@@ -524,7 +524,7 @@ Some (working) examples::
     [setup/ansible-slurm]
     provider=ansible
     frontend_groups=slurm_master
-    compute_groups=slurm_clients
+    compute_groups=slurm_workers
 
     [setup/ansible-gridengine]
     provider=ansible

--- a/docs/playbooks.rst
+++ b/docs/playbooks.rst
@@ -87,7 +87,7 @@ the ``setup`` stanza will look like::
 
     [setup/ansible_slurm]
     frontend_groups=slurm_master,ganglia_master
-    compute_groups=slurm_clients,ganglia_monitor
+    compute_groups=slurm_workers,ganglia_monitor
     ...
 
 Extra variables can be set by editing the `setup/` section:
@@ -449,7 +449,7 @@ You can combine, for instance, a SLURM cluster with a PVFS2 cluster::
 
     [setup/ansible_slurm+pvfs2]
     frontend_groups=slurm_master,pvfs2_client
-    compute_groups=slurm_clients,pvfs2_client
+    compute_groups=slurm_workers,pvfs2_client
     pvfs-nodes_groups=pvfs2_meta,pvfs2_data
     ...
 

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -316,7 +316,7 @@ user_key_public=~/.ssh/id_rsa.pub
 #
 #                 - slurm_master: configure this machine as slurm masternode
 #
-#                 - slurm_clients: compute nodes of a slurm cluster
+#                 - slurm_workers: compute nodes of a slurm cluster
 #
 #                 - gridengine_master: configure as gridengine masternode
 #
@@ -366,7 +366,7 @@ user_key_public=~/.ssh/id_rsa.pub
 [setup/ansible-slurm]
 provider=ansible
 frontend_groups=slurm_master
-compute_groups=slurm_clients
+compute_groups=slurm_workers
 
 [setup/ansible-gridengine]
 provider=ansible

--- a/elasticluster/share/playbooks/README.rst
+++ b/elasticluster/share/playbooks/README.rst
@@ -64,7 +64,7 @@ In order to configure a slurm cluster, create an hosts file with::
     [slurm_master]
     hostname ansible_ssh_host=A.B.C.D
 
-    [slurm_clients]
+    [slurm_workers]
     node1 ansible_ssh_host=A.B.C.D
     node2 ansible_ssh_host=A.B.C.D
     node3 ansible_ssh_host=A.B.C.D


### PR DESCRIPTION
Followup for:
- rename slurm_clients in tests: ae76efb7
- update SLURM playbook: 5afb1423
- warn users that class `slurm_clients` has been renamed to `slurm_workers`.: 22ffafec