### PR TITLE
Install MAUI scheduler from RPM

### DIFF
--- a/elasticluster/share/playbooks/roles/pbs+maui/handlers/main.yml
+++ b/elasticluster/share/playbooks/roles/pbs+maui/handlers/main.yml
@@ -7,6 +7,6 @@
   action: service name=pbs_server state=restarted
   when: is_centos
 
-- name: restart maui
-  action: service name=maui state=restarted
+- name: restart maui.d
+  action: service name=maui.d state=restarted
   when: is_centos

--- a/elasticluster/share/playbooks/roles/pbs+maui/tasks/maui.yml
+++ b/elasticluster/share/playbooks/roles/pbs+maui/tasks/maui.yml
@@ -1,9 +1,7 @@
 ---
-- name: Install MAUI package
+- name: Install MAUI RPM from a remote repo
   when: is_centos
-  action: yum pkg={{item}} state=latest
-  with_items:
-    - maui
+  yum: name=http://ftp.cs.stanford.edu/pub/rpms/centos/6.2/x86_64/maui-3.3.1-x86_64-fpmbuild.rpm state=present
 
 - name: Ensure /var/spool/maui/log directory exists
   action: file path=/var/spool/maui/log state=directory
@@ -12,8 +10,8 @@
   when: is_centos
   action: service name={{item}} state=started
   with_items:
-    - maui
+    - maui.d
 
 - name: Check maui configuration
-  action: template src=pbs+maui/templates/var/spool/maui/maui.cfg.j2 dest=/var/spool/maui/maui.cfg
-  notify: restart maui
+  action: template src=pbs+maui/templates/var/spool/maui/maui.cfg.j2 dest=/usr/local/maui/maui.cfg
+  notify: restart maui.d


### PR DESCRIPTION
MAUI is not available in any of the installed repositories anymore, so it's fetched
as an RPM directly. The package provides it as "maui.d" so services calls are updated
accordingly.