### PR TITLE
Add NUMA workaround for PBS

### DIFF
--- a/elasticluster/share/playbooks/roles/pbs+maui/templates/var/spool/torque/server_priv/nodes.j2
+++ b/elasticluster/share/playbooks/roles/pbs+maui/templates/var/spool/torque/server_priv/nodes.j2
@@ -1,3 +1,3 @@
 {% for host in groups['pbs_clients'] %}
-{{ host }} np={{ hostvars[host].ansible_processor_count }}
+{{ host }} np={{ hostvars[host].ansible_processor_count }} num_node_boards=1
 {% endfor %}


### PR DESCRIPTION
PBS does not work correctly on a single compute node with NUMA support. More
information can be found at [https://bugzilla.redhat.com/show_bug.cgi?id=1321154](https://bugzilla.redhat.com/show_bug.cgi?id=1321154).