### PR TITLE
Apply dynamic include workaround for Ansible playbooks

### DIFF
--- a/elasticluster/share/playbooks/roles/pbs+maui.yml
+++ b/elasticluster/share/playbooks/roles/pbs+maui.yml
@@ -14,18 +14,24 @@
         options: 'rw,no_root_squash,async'
   tasks: 
     - include: pbs+maui/tasks/master.yml
+      static: yes
     - include: cluster/tasks/packages.yml
+      static: yes
   handlers:
     - include: slurm/handlers/main.yml
     - include: common/handlers/main.yml
+      static: yes
     - include: pbs+maui/handlers/main.yml
+      static: yes
 
 - name: MAUI masternode Playbook
   hosts: maui_master
   tasks: 
     - include: pbs+maui/tasks/maui.yml
+      static: yes
   handlers:
     - include: pbs+maui/handlers/main.yml
+      static: yes
 
 - name: PBS worker nodes Playbook
   hosts: pbs_clients
@@ -37,7 +43,10 @@
         options: 'rw,async'
   tasks: 
     - include: pbs+maui/tasks/clients.yml
+      static: yes
     - include: cluster/tasks/packages.yml
+      static: yes
   handlers:
     - include: pbs+maui/handlers/main.yml
+      static: yes
 


### PR DESCRIPTION
There seems to be regression in Ansible that breaks dynamic includes with
every few minor releases. This workaround turns the includes into static
includes which work across all versions. More information can be found in
this Google Groups discussion:

 https://groups.google.com/forum/#!msg/ansible-devel/9aJaoVeRdOg/B4TvRTLgCAAJ
