### PR TITLE
[WIP] Mask munge service from starting on install to fix permissions error

### DIFF
--- a/elasticluster/share/playbooks/roles/common/tasks/deb.yml
+++ b/elasticluster/share/playbooks/roles/common/tasks/deb.yml
@@ -14,7 +14,7 @@
 
 - name: Upgrade all installed packages to latest version
   apt:
-    upgrade=safe
+    upgrade=dist
   when: is_debian_or_ubuntu
   
 - name: Ensure additional packages are installed
@@ -22,7 +22,7 @@
     name={{item}}
     state=present
   with_items:
-    - aptitude
+#    - aptitude
     - python-apt
     - sysvinit-utils
     - software-properties-common

--- a/elasticluster/share/playbooks/roles/slurm-common/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/slurm-common/tasks/main.yml
@@ -90,7 +90,7 @@
     - dmtcp
     - libopenmpi-dev
     - openmpi-bin
-    - openmpi-checkpoint
+    #- openmpi-checkpoint
   when: '{{is_debian_or_ubuntu}}'
 
 

--- a/elasticluster/share/playbooks/roles/slurm-common/tasks/munge.yml
+++ b/elasticluster/share/playbooks/roles/slurm-common/tasks/munge.yml
@@ -1,16 +1,25 @@
 # Install and configure the MUNGE authentication service
 ---
 
-- name: Install MUNGE (Debian/Ubuntu)
+- block:
+  - name: Mask MUNGE from starting on install
+    command: systemctl mask munge.service creates=/etc/systemd/system/munge.service
+    when: ansible_service_mgr == 'systemd'
+  - name: Install MUNGE (Debian/Ubuntu)
+    package:
+      pkg=munge
+      state=latest
+  - name: Unmask MUNGE from starting on install
+    command: systemctl unmask munge.service && systemctl daemon-reload removes=/etc/systemd/system/munge.service
+    when: ansible_service_mgr == 'systemd'
+  - name:  Reload systemd
+    command: systemctl daemon-reload
+    when: ansible_service_mgr == 'systemd'
   tags:
     - slurm
     - munge
     - debian
-  package:
-    pkg=munge
-    state=latest
-  when:
-    is_debian_compatible
+  when: is_debian_compatible
 
 
 - name: Install MUNGE (RHEL-compatible)
@@ -38,7 +47,18 @@
     state=present
   when: is_ubuntu_trusty
 
-  
+- name: patch `/lib/systemd/system/munge.service` on Ubuntu >= 14.10
+  tags:
+    - slurm
+    - munge
+    - ubuntu
+  lineinfile:
+    dest='/lib/systemd/system/munge.service'
+    line='ExecStart=/usr/sbin/munged --syslog'
+    regexp='^ExecStart=/usr/sbin/munged'
+    state=present
+  when: is_ubuntu_14_10_or_later
+
 - name: Configure MUNGE
   tags:
     - slurm


### PR DESCRIPTION
I would appreciate any feedback regarding Ansible best practices or suggestions for a better approach to resolve these issues.

Issue 1a: Munge Daemon Logfile Security Check
-----------------------------------------------------------------

Ubuntu 15.04 switched to systemd and granted group write permission to `/var/log` for the group `syslog`.

The SLURM Munge service expects `/var/log/` to be writeable exclusively by either `root` or `munge`. As a result the munge service will raise the following error:

>   munged: Error: Logfile is insecure: group-writable permissions set on "/var/log"
     dun/munge/issues/31

Munge has fixed the permissions issue with commit https://github.com/dun/munge/commit/ec4a2c679d43db5e194434bdc7489e1a92599aa5, but previous versions must start the daemon with the `--syslog` flag to disable the error.

Issue 1b: Ubuntu/Debian Starts Daemons on Install
--------------------------------------------------------------------

Because Ubuntu starts the munge daemon on install, the task will fail before another task can append the `--syslog` flag munge.service.

Issue 2: Install dependencies
---------------------------------------

`openmpi-checkpoint` package was not found in the Ubuntu/Xenial repository

A sudo security error was triggered by the [requiretty](https://bugzilla.redhat.com/show_bug.cgi?id=1020147) option in the sudoers file while installing aptitude.

> sorry, you must have a tty to run sudo

The ansible apt module will use `aptitude` to install upgrades with the `upgrade=safe` flag, but `apt-get` with `upgrade=dist`.

Solution 1:
--------------

The pull request is [masking](https://fedoramagazine.org/systemd-masking-units/) the munge.service to prevent Ubuntu from starting the munge daemon on install followed by appending `--syslog` to the munge.service to resolve the permissions error.

"Solution 2":
----------------

Avoid installing the problematic dependencies because I wanted it to get it working and am not yet aware of a better solution. Removing the `requiretty` option from the sudoers file might resolve the sudo error, but given it is deliberately turned on by the distribution maintainers I am less inclined to disable it without understanding the implications.


<!---
@huboard:{"order":298.1490298029802,"milestone_order":292,"custom_state":""}
-->
