### PR TITLE
added support for ec2 spot instances

### DIFF
--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -597,4 +597,10 @@ ssh_to=controller
 #
 # [cluster/slurm/frontend]
 # flavor=bigdisk
-
+#
+# To request ec2 spot instance specify price 
+# and (optional) timeout for node
+# [cluster/aws-slurm/compute]
+# price=0.08
+# timeout=600
+# flavor=m3.large


### PR DESCRIPTION
Added basic support for ec2 spot instances.
Provide a price argument to the BotoProvider start_instance method to request a spot instance.
You can also provide an optional timeout (s) to determine how long the provider will wait for the request to be fulfilled.

I also added an example to the cluster config to show how a cluster can be launched with spot compute nodes (while using non-spot for the frontend )