### PR TITLE
Enable increase disk of the root volume  for ec2_boto provider

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -703,7 +703,9 @@ Optional configuration keys
     Define the size of boot disk to use.
     Only supported when the cloud provider is `google`.
     Values are specified in gigabytes.
-    Default value is 10.
+    Default value is 10 for `google`.
+    Now supports `ec2_boto` boot_disk_size. 
+    Default value is 8 for `ec2_boto`.
 
 ``tags``
     Comma-separated list of instance tags.

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -256,7 +256,7 @@ class BotoCloudProvider(AbstractCloudProvider):
                     request=connection.get_all_spot_instance_requests(request_ids=request.id)[-1]
             else:
 
-                if not boot_disk_size or int( boot_disk_size > 0):
+                if not boot_disk_size or int( boot_disk_size > 8):
                     dev_sda1 = ec2.blockdevicemapping.EBSBlockDeviceType()
                     dev_sda1.size = int(boot_disk_size)
                     dev_sda1.delete_on_termination = True

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -222,10 +222,11 @@ class BotoCloudProvider(AbstractCloudProvider):
             if price:
                 log.info("Requesting spot instance with price `%s` ...", price)
 
-                if not boot_disk_size or int( boot_disk_size > 0):
-                    dev_sda1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
-                    dev_sda1.size = boot_disk_size
-                    bdm = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+                if not boot_disk_size or int( boot_disk_size > 8):
+                    dev_sda1 = ec2.blockdevicemapping.EBSBlockDeviceType()
+                    dev_sda1.size = int(boot_disk_size)
+                    dev_sda1.delete_on_termination = True
+                    bdm = ec2.blockdevicemapping.BlockDeviceMapping()
                     bdm['/dev/sda1'] = dev_sda1
 
                     request = connection.request_spot_instances(
@@ -256,10 +257,12 @@ class BotoCloudProvider(AbstractCloudProvider):
             else:
 
                 if not boot_disk_size or int( boot_disk_size > 0):
-                    dev_sda1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
-                    dev_sda1.size = boot_disk_size
-                    bdm = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+                    dev_sda1 = ec2.blockdevicemapping.EBSBlockDeviceType()
+                    dev_sda1.size = int(boot_disk_size)
+                    dev_sda1.delete_on_termination = True
+                    bdm = ec2.blockdevicemapping.BlockDeviceMapping()
                     bdm['/dev/sda1'] = dev_sda1
+
 
                     reservation = connection.run_instances(
                        image_id, key_name=key_name, security_groups=security_groups,

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -160,7 +160,7 @@ class BotoCloudProvider(AbstractCloudProvider):
     def start_instance(self, key_name, public_key_path, private_key_path,
                        security_group, flavor, image_id, image_userdata,
                        username=None, node_name=None, network_ids=None,
-                       price=None,timeout=None,
+                       price=None,timeout=None,boot_disk_size=8,
                        **kwargs):
         """Starts a new instance on the cloud using the given properties.
         The following tasks are done to start an instance:
@@ -181,6 +181,9 @@ class BotoCloudProvider(AbstractCloudProvider):
         :param str image_id: image type (os) to use for the instance
         :param str image_userdata: command to execute after startup
         :param str username: username for the given ssh key, default None
+
+        Specific to AWS EC2
+        :param int boot_disk_size: boot_disk_size , default for EC2 is 8Gb
 
         :return: str - instance id of the started instance
         """
@@ -214,10 +217,25 @@ class BotoCloudProvider(AbstractCloudProvider):
             security_groups = [security_group]
 
         try:
+
             #start spot instance if bid is specified
             if price:
                 log.info("Requesting spot instance with price `%s` ...", price)
-                request = connection.request_spot_instances(
+
+                if not boot_disk_size or int( boot_disk_size > 0):
+                    dev_sda1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+                    dev_sda1.size = boot_disk_size
+                    bdm = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+                    bdm['/dev/sda1'] = dev_sda1
+
+                    request = connection.request_spot_instances(
+                                price,image_id, key_name=key_name, security_groups=security_groups,
+                                instance_type=flavor, user_data=image_userdata,
+                                network_interfaces=interfaces,
+                                block_device_map = bdm,
+                                instance_profile_name=self._instance_profile)[-1]
+                else:
+                    request = connection.request_spot_instances(
                                 price,image_id, key_name=key_name, security_groups=security_groups,
                                 instance_type=flavor, user_data=image_userdata,
                                 network_interfaces=interfaces,
@@ -236,11 +254,26 @@ class BotoCloudProvider(AbstractCloudProvider):
                     # update request status
                     request=connection.get_all_spot_instance_requests(request_ids=request.id)[-1]
             else:
-                reservation = connection.run_instances(
-                    image_id, key_name=key_name, security_groups=security_groups,
-                    instance_type=flavor, user_data=image_userdata,
-                    network_interfaces=interfaces,
-                    instance_profile_name=self._instance_profile)
+
+                if not boot_disk_size or int( boot_disk_size > 0):
+                    dev_sda1 = boto.ec2.blockdevicemapping.EBSBlockDeviceType()
+                    dev_sda1.size = boot_disk_size
+                    bdm = boto.ec2.blockdevicemapping.BlockDeviceMapping()
+                    bdm['/dev/sda1'] = dev_sda1
+
+                    reservation = connection.run_instances(
+                       image_id, key_name=key_name, security_groups=security_groups,
+                       instance_type=flavor, user_data=image_userdata,
+                       network_interfaces=interfaces,
+                       block_device_map = bdm,
+                       instance_profile_name=self._instance_profile)
+                else:
+                    reservation = connection.run_instances(
+                       image_id, key_name=key_name, security_groups=security_groups,
+                       instance_type=flavor, user_data=image_userdata,
+                       network_interfaces=interfaces,
+                       instance_profile_name=self._instance_profile)
+
         except Exception as ex:
             log.error("Error starting instance: %s", ex)
             if "TooManyInstances" in ex:

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -488,6 +488,8 @@ worker_groups=ipython_engine
 #                 Only supported when the cloud provider is `google`.
 #                 Values are specified in gigabytes.
 #                 Default value is 10.
+#    Now supports `ec2_boto` boot_disk_size.
+#    Default value is 8 for `ec2_boto`.
 #
 # tags: Comma-separated list of instance tags.
 #       Only supported when the cloud provider is `google`.


### PR DESCRIPTION
Sample parameter for increasing root disk.
``` 
[cluster/aws-slurm/frontend]
flavor=m1.small
boot_disk_size=20

[cluster/aws-slurm/compute]
flavor=m1.small
boot_disk_size=20
```