### PR TITLE
Fixed a bug with a conditional which was always true.

### DIFF
--- a/elasticluster/share/playbooks/roles/iptables/tasks/init-Debian.yml
+++ b/elasticluster/share/playbooks/roles/iptables/tasks/init-Debian.yml
@@ -10,7 +10,7 @@
     service:
       'iptables':  'netfilter-persistent'
       'ip6tables': 'netfilter-persistent'
-  when: '{% if is_debian_compatible and ((is_debian_8_or_later) or (is_ubuntu_15_10_or_later)) %}true{% else %}false{% endif %}'
+  when: ({{ is_ubuntu_15_10_or_later }} or {{ is_debian_8_or_later }}) 
 
 
 - name: Load configuration and service names (older Debian/Ubuntu)
@@ -23,4 +23,4 @@
     service:
       'iptables':  'iptables-persistent'
       'ip6tables': 'iptables-persistent'
-  when: '{% if is_debian_compatible and not ((is_debian_8_or_later) or (is_ubuntu_15_10_or_later)) %}true{% else %}false{% endif %}'
+  when: not ({{ is_ubuntu_15_10_or_later }} or {{ is_debian_8_or_later }})


### PR DESCRIPTION
OS version (for Ubuntu 14.04) wasn't being properly recognized causing ansible to try to restart  (non-existent) service the netfilter-persistent.
This commit fixes this problem (at least on Ubuntu 14.04).