### PR TITLE
change pytest to tool:pytest to remove a warning in the tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = docs elasticluster/share .* build dist *.egg


### PR DESCRIPTION
`py.test --cov=elasticluster` gives the following warning: 

`WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.`

This PR updates setup.cfg to remove that warning.