### PR TITLE
Update glusterfs to version 3.8

### DIFF
--- a/elasticluster/share/playbooks/roles/glusterfs-common/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/glusterfs-common/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
 # version of the SW to install
-glusterfs_version: '3.7'
+glusterfs_version: '3.8'


### PR DESCRIPTION
Glusterfs 3.8 has been released. It supports Ubuntu Yakkety while version 3.7 does not. This created an error when trying to build a Slurm cluster using Ubuntu Yakkety image.