### PR TITLE
Fix EC2 deprecation warning

### DIFF
--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -381,7 +381,7 @@ class BotoCloudProvider(AbstractCloudProvider):
         The returned dictionary links VM id with the actual VM object.
         """
         connection = self._connect()
-        reservations = connection.get_all_instances()
+        reservations = connection.get_all_reservations()
         cached_instances = {}
         for rs in reservations:
             for vm in rs.instances:


### PR DESCRIPTION
This fixes a deprecation warning printed by the EC2 boto API.