### PR TITLE
Add documentation how to use Google Compute Engine private image

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -628,7 +628,10 @@ Mandatory configuration keys
 ``image_id``
 
     image id in `ami` format. If you are using OpenStack, you need to
-    run `euca-describe-images` to get a valid `ami-*` id.
+    run `euca-describe-images` to get a valid `ami-*` id. With Google 
+    Compute Engine you can also use a URL of a private image. `gcloud 
+    compute images describe <your_image_name>` will show the selfLink 
+    URL to use.
 
 ``flavor``
 

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -426,7 +426,9 @@ worker_groups=ipython_engine
 #
 # image_id: image id in `ami` format. If you are using OpenStack, you
 #           need to run `euca-describe-images` to get a valid `ami-*`
-#           id.
+#           id. With Google Compute Engine you can also use a URL of 
+#           a private image. `gcloud compute images describe 
+#           <your_image_name>` will show the selfLink URL to use.
 #
 # flavor: the image type to use. Different cloud providers call it
 #         differently, could be `instance type`, `instance size` or


### PR DESCRIPTION
This is a feature that I wanted to use and I had to search trough the pull request #138 to understand its use. This documentation should make it easier for the users to use it.