### PR TITLE
#183 / #267: Document configuration to get Ansible SSH pipelining to work on CentOS/RHEL

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -320,7 +320,13 @@ run sudo``.  Apparently RHEL and CentOS ship with a default
 configuration that requires an interactive terminal to run ``sudo``;
 this is not there when ``sudo`` is run remotely from Ansible.
 
-The solution is to turn `SSH pipelining`_ off.  There are two ways of
+You can use the ``image_userdata`` key to configure ``sudo`` properly for your SSH user::
+
+        [cluster/sge]
+        image_userdata=#!/bin/bash
+          echo 'Defaults:centos !requiretty' > /etc/sudoers.d/999-requiretty && chmod 440 /etc/sudoers.d/999-requiretty
+
+Another solution is to turn `SSH pipelining`_ off.  There are two ways of
 doing this:
 
 1. Add the line ``ansible_ssh_pipelining=no`` in the cluster


### PR DESCRIPTION
Related: #183 / #267

This documents a trick to get SSH pipelining to work on CentOS/RHEL: use the "User Data" script to configure sudo properly before Ansible connects.

(only tested on EC2)