### PR TITLE
Put short hostnames first in hosts file

### DIFF
--- a/elasticluster/share/playbooks/roles/common/templates/etc/hosts.j2
+++ b/elasticluster/share/playbooks/roles/common/templates/etc/hosts.j2
@@ -7,5 +7,6 @@
 
 {% for host in hosts|default(groups['all'])|sort if not host.startswith('localhost') %}
 {%- set fqdn = hostvars[host].ansible_fqdn -%}
-{{hostvars[host].ansible_default_ipv4.address}} {% if not fqdn.startswith('localhost') %}{{fqdn}} {{fqdn.split('.')[0]}}{% endif %} {{host}}
+{{hostvars[host].ansible_default_ipv4.address}} {{host}} {% if not fqdn.startswith('localhost') %}{{fqdn}} {{fqdn.split('.')[0]}}{% endif %}
+
 {% endfor -%}


### PR DESCRIPTION
With current configuration, SGE uses the `ip-XXX-XXX-XXX-XXX` in `qhost`, and `ip-XXX-XXX-XXX-XXX.eu-west-1.compute.internal` in `qstat`, which makes pretty hard to administer the cluster...

SGE picks the name in first position in `/etc/hosts` ([related mailing list thread](http://gridengine.org/pipermail/users/2016-December/009469.html)).

Only tested on EC2 with CentOS 6/7 and SGE+Ganglia playbooks.
