### PR TITLE
Added google-compute-enging to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ setup(
         'boto',
         # GCE cloud
         'google-api-python-client',
+        'google-compute-engine',
         'python-gflags',
         'simplejson>=2.5.0', # needed by `uritemplate` but somehow not picked up
         'pytz',   ## required by `positional` but somehow not picked up


### PR DESCRIPTION
After install, elasticluster list-templates produces the error below.
Adding `google-compute-engine` to the list of `install_requires`, fixes the problem.

```(elasticluster)rk@debian8-rk:~$ elasticluster list-templates
Traceback (most recent call last):
  File "/home/rk/elasticluster/bin/elasticluster", line 11, in <module>
    load_entry_point('elasticluster', 'console_scripts', 'elasticluster')()
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 561, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2631, in load_entry_point
    return ep.load()
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2291, in load
    return self.resolve()
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2297, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/rk/elasticluster/src/elasticluster/__init__.py", line 31, in <module>
    from elasticluster.providers.ec2_boto import BotoCloudProvider
  File "/home/rk/elasticluster/src/elasticluster/providers/ec2_boto.py", line 27, in <module>
    import boto
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/boto/__init__.py", line 1216, in <module>
    boto.plugin.load_plugins(config)
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/boto/plugin.py", line 93, in load_plugins
    _import_module(file)
  File "/home/rk/elasticluster/local/lib/python2.7/site-packages/boto/plugin.py", line 75, in _import_module
    return imp.load_module(name, file, filename, data)
  File "/usr/lib/python2.7/dist-packages/google_compute_engine/boto/compute_auth.py", line 19, in <module>
    from google_compute_engine import logger
ImportError: No module named google_compute_engine```