### PR TITLE
Fixed gce.py so that ~ can be used in user_key_* parameters of config.

### DIFF
--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -307,7 +307,13 @@ class GoogleCloudProvider(AbstractCloudProvider):
         else:
             instance_id = 'elasticluster-%s' % uuid.uuid4()
 
-        public_key_content = file(public_key_path).read()
+        # Use the with keyword so that the file is properly closed.
+        # For os.path.expanduser, if the expansion fails or if the path does
+        # not begin with a tilde, the path is returned unchanged. If the
+        # returned path is a relative path, determine the absolute path and use
+        # that to open the file.
+        with open(os.path.abspath(os.path.expanduser(public_key_path)), 'r') as f:
+            public_key_content = f.read()
 
         instance = {
             'name': instance_id,


### PR DESCRIPTION
Made fix so that relative paths using ~/ can be used with parameters user_key_private and user_key_public in the login section of .elasticluster/config for GCE.

Executing the command `elasticluster start my_cluster` with the following login section:
```
[login/google]
image_user=my_username
image_user_sudo=root
image_sudo=True
user_key_name=elasticluster
user_key_private=~/.ssh/google_compute_engine
user_key_public=~/.ssh/google_compute_engine.pub
```
Produces errors such as the following:
```
2017-01-23 06:35:33 ncbiblast-2 gc3.elasticluster[16705] ERROR Could not start node `frontend001`: [Errno 2] No such file or directory: '~/.ssh/google_compute_engine.pub' -- <type 'exceptions.IOError'>
```