### PR TITLE
Change mentions of slurm_workers to slurm_worker in the documentation

### DIFF
--- a/docs/api/elasticluster.rst
+++ b/docs/api/elasticluster.rst
@@ -144,7 +144,7 @@ types on other cloud providers can be setup accordingly.
     # Initialising the setup provider needs a little more preparation:
     # the groups dictionary specifies the kind of nodes used for this cluster.
     # In this case we want a frontend and a compute kind. The frontend node
-    # (s) will be setup as slurm_master, the compute node(s) as slurm_workers.
+    # (s) will be setup as slurm_master, the compute node(s) as slurm_worker.
     # This corresponds to the documentation of the ansible playbooks
     # provided with elasticluster. The kind of the node is a name specified
     # by the user. This name will be used to set a new hostname on the
@@ -152,7 +152,7 @@ types on other cloud providers can be setup accordingly.
     # groups['kind'] = ['andible_group1', 'ansible_group2']
     groups = dict()
     groups['frontend'] = ['slurm_master']
-    groups['compute'] = ['slurm_workers']
+    groups['compute'] = ['slurm_worker']
 
     setup_provider = elasticluster.AnsibleSetupProvider(groups)
 

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -486,7 +486,7 @@ The following configuration keys are only valid if `provider` is
     ``slurm_master``
         configure this machine as slurm masternode
 
-    ``slurm_workers``
+    ``slurm_worker``
         compute nodes of a slurm cluster
 
     ``ganglia_master``
@@ -500,7 +500,7 @@ The following configuration keys are only valid if `provider` is
     combinations make sense. A common setup is, for instance::
 
         frontend_groups=slurm_master,ganglia_master,ganglia_monitor
-        compute_groups=slurm_workers,ganglia_monitor
+        compute_groups=slurm_worker,ganglia_monitor
 
     This will configure the frontend node as slurm master and ganglia
     frontend, and the compute nodes as clients for both slurm and
@@ -597,7 +597,7 @@ Some (working) examples::
     [setup/ansible-slurm]
     provider=ansible
     frontend_groups=slurm_master
-    compute_groups=slurm_workers
+    compute_groups=slurm_worker
 
     [setup/ansible-gridengine]
     provider=ansible

--- a/docs/playbooks.rst
+++ b/docs/playbooks.rst
@@ -64,7 +64,7 @@ front-end::
 
     [setup/slurm+ansible]
     master_groups=slurm_master,ansible
-    worker_groups=slurm_workers
+    worker_groups=slurm_worker
     # ...
 
 
@@ -80,7 +80,7 @@ Supported on:
 This playbook installs the `SLURM`_ batch-queueing system.
 
 You are supposed to only define one ``slurm_master`` and multiple
-``slurm_workers``. The first will act as login node, NFS server for
+``slurm_worker``. The first will act as login node, NFS server for
 the ``/home`` filesystem, and runs the SLURM scheduler and accounting
 database; the workers will only execute the jobs.  A ``slurm_submit``
 role allows you to optionally install "SLURM client" nodes, i.e.,
@@ -93,7 +93,7 @@ Ansible group      Action
 ``slurm_master``   SLURM controller/scheduler node; also runs the
                    accounting storage daemon `slurmdbd` and its
                    MySQL/MariaDB backend.
-``slurm_workers``  SLURM execution node: runs the `slurmd` daemon.
+``slurm_worker``   SLURM execution node: runs the `slurmd` daemon.
 ``slurm_submit``   SLURM client: has all the submission and query
                    commands installed, but runs no daemon.
 =================  ==================================================
@@ -110,7 +110,7 @@ cluster using 1 front-end and 4 execution nodes::
 
     [setup/slurm]
     master_groups=slurm_master
-    worker_groups=slurm_workers
+    worker_groups=slurm_worker
     # ...
 
 You can combine the SLURM playbook with the Ganglia one; in this case
@@ -118,7 +118,7 @@ the ``setup`` stanza will look like::
 
     [setup/ansible_slurm]
     frontend_groups=slurm_master,ganglia_master
-    compute_groups=slurm_workers,ganglia_monitor
+    compute_groups=slurm_worker,ganglia_monitor
     ...
 
 Extra variables can be set by editing the `setup/` section:
@@ -480,7 +480,7 @@ You can combine, for instance, a SLURM cluster with a PVFS2 cluster::
 
     [setup/ansible_slurm+orangefs]
     frontend_groups=slurm_master,pvfs2_client
-    compute_groups=slurm_workers,pvfs2_client
+    compute_groups=slurm_worker,pvfs2_client
     orangefs_groups=pvfs2_meta,pvfs2_data
     ...
 

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -320,7 +320,7 @@ user_key_public=~/.ssh/id_rsa.pub
 #
 #                 - slurm_master: configure this machine as slurm masternode
 #
-#                 - slurm_workers: compute nodes of a slurm cluster
+#                 - slurm_worker: compute nodes of a slurm cluster
 #
 #                 - gridengine_master: configure as gridengine masternode
 #
@@ -370,7 +370,7 @@ user_key_public=~/.ssh/id_rsa.pub
 [setup/ansible-slurm]
 provider=ansible
 frontend_groups=slurm_master
-compute_groups=slurm_workers
+compute_groups=slurm_worker
 
 [setup/ansible-gridengine]
 provider=ansible

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -848,7 +848,7 @@ ssh_to=master
 # [setup/ansible-slurm]
 # provider=ansible
 # frontend_groups=slurm_master
-# compute_groups=slurm_workers
+# compute_groups=slurm_worker
 
 # [setup/ansible-gridengine]
 # provider=ansible
@@ -993,7 +993,7 @@ ssh_to=master
 # [setup/ansible-slurm]
 # provider=ansible
 # frontend_groups=slurm_master
-# compute_groups=slurm_workers
+# compute_groups=slurm_worker
 
 # [cluster/slurm]
 # cloud=hobbes-new
@@ -1064,7 +1064,7 @@ ssh_to=master
 # [setup/ansible-slurm]
 # provider=ansible
 # frontend_groups=slurm_master
-# compute_groups=slurm_workers
+# compute_groups=slurm_worker
 #     '''
 
 #     def test_read_multiple_config1(self):


### PR DESCRIPTION
While the code has been changed to use `slurm_worker` everywhere and warn the user if `slurm_workers` was used, the documentation has not been changed yet.