### PR TITLE
Upgrade anaconda to version 4.2.0

### DIFF
--- a/elasticluster/share/playbooks/roles/anaconda/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/anaconda/defaults/main.yml
@@ -7,7 +7,7 @@
 anaconda_mirror : 'http://repo.continuum.io/archive'
 
 # Version of the Anaconda distribution to install
-anaconda_version : '4.1.1'
+anaconda_version : '4.2.0'
 
 # Anaconda comes with either a Python2 or a Python3 interpreter
 # -- choose which one you want here.


### PR DESCRIPTION
The latest stable version of [Anaconda is 4.2.0](https://www.continuum.io/downloads). I upgraded the version in the playbook.