### PR TITLE
Fixing 100% CPU on gmond for cluster nodes

### DIFF
--- a/elasticluster/share/playbooks/roles/ganglia/templates/gmond.conf.j2
+++ b/elasticluster/share/playbooks/roles/ganglia/templates/gmond.conf.j2
@@ -11,7 +11,11 @@ globals {
   debug_level = 0               
   max_udp_msg_len = 1472        
   mute = no             
-  deaf = no             
+  {% if inventory_hostname in groups['ganglia_monitor'] and not inventory_hostname in groups['ganglia_master'] %}
+  deaf = yes
+  {% elif inventory_hostname in groups['ganglia_master'] %}
+  deaf = no
+  {% endif %}             
   host_dmax = 0 /*secs */ 
   cleanup_threshold = 300 /*secs */ 
   gexec = no             


### PR DESCRIPTION
After starting a cluster (slurm, ganglia) I discover that gmond uses 100% on all compute nodes. This happens on ubuntu 14.04 and 16.04.
This fix differ configuration between ganglia_monitor and ganglia_master.