### PR TITLE
Add boot_disk_size, boot_disk_type, scheduling, node_name and tags to…

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -599,6 +599,11 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
             'login',
             'network_ids',
             'security_group',
+            'node_name',
+            'boot_disk_size',
+            'boot_disk_type',
+            'scheduling',
+            'tags'
             #'user_key_name',    ## from `login/*`
             #'user_key_private', ## from `login/*`
             #'user_key_public',  ## from `login/*`

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -87,9 +87,8 @@ boot_disk_size=100
     assert cluster.nodes['master'][0].extra['boot_disk_size'] == '100'
     # "worker" nodes take values from the cluster defaults
     assert cluster.nodes['worker'][0].flavor == 'n1-standard-1'
-    # FIXME: Actually, does this imply that the `boot_disk_size` value
-    # defined at cluster level is not propagated to "worker" nodes?
-    assert 'boot_disk_size' not in cluster.nodes['worker'][0].extra
+    assert 'boot_disk_size' in cluster.nodes['worker'][0].extra
+    assert cluster.nodes['worker'][0].extra['boot_disk_size'] == '20'
 
 
 def test_issue_415(tmpdir):

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -128,6 +128,11 @@ image_id = i-12345
 login = ubuntu
 flavor = m1.tiny
 security_group = default
+boot_disk_size = 15
+boot_disk_type = pd-standard
+node_name = my-node
+scheduling = preemptible
+tags = tag1,tag2,tag3
 
 
 [cluster/wrong_example_google]
@@ -229,6 +234,11 @@ CONFIG_RAW = ({
         'login': 'ubuntu',
         'flavor': 'm1.tiny',
         'security_group': 'default',
+        'boot_disk_size': '15',
+        'boot_disk_type' : 'pd-standard',
+        'node_name' : 'my-node',
+        'scheduling' : 'preemptible',
+        'tags' : 'tag1,tag2,tag3'
     },
 
     'cluster/wrong_example_google': {
@@ -325,6 +335,11 @@ CONFIG_TREE = ({
             'login': 'ubuntu',
             'flavor': 'm1.tiny',
             'security_group': 'default',
+            'boot_disk_size': '15',
+            'boot_disk_type': 'pd-standard',
+            'node_name': 'my-node',
+            'scheduling': 'preemptible',
+            'tags': 'tag1,tag2,tag3'
         },
         'wrong_example_google': {
             'cloud': 'wrongle',
@@ -423,6 +438,11 @@ CONFIG_TREE_WITH_RENAMES = ({
             'login': 'ubuntu',
             'flavor': 'm1.tiny',
             'security_group': 'default',
+            'boot_disk_size': '15',
+            'boot_disk_type': 'pd-standard',
+            'node_name': 'my-node',
+            'scheduling': 'preemptible',
+            'tags': 'tag1,tag2,tag3'
         },
         'wrong_example_google': {
             'cloud': 'wrongle',
@@ -459,7 +479,6 @@ def test_read_config_file(tmpdir):
         cfgfile.flush()
         raw_config = _read_config_files([cfgfile.name])
     assert raw_config == CONFIG_RAW
-
 
 def test_arrange_config_tree():
     tree = _arrange_config_tree(copy(CONFIG_RAW))
@@ -515,3 +534,17 @@ def test_build_node_section():
     assert nodes_cfg['misc']['image_id'] == 'i-12345'
     assert nodes_cfg['misc']['num'] == 10
     assert nodes_cfg['misc']['min_num'] == 10
+
+
+def test_build_node_section_google():
+    deref_tree = _dereference_config_tree(deepcopy(CONFIG_TREE_WITH_RENAMES))
+    cfg = _build_node_section(deref_tree)['cluster']
+    cluster_cfg = cfg['example_google']
+    assert 'nodes' in cluster_cfg
+    nodes_cfg = cluster_cfg['nodes']
+    assert 'misc' in nodes_cfg
+    assert nodes_cfg['misc']['boot_disk_size'] == '15'
+    assert nodes_cfg['misc']['boot_disk_type'] == 'pd-standard'
+    assert nodes_cfg['misc']['scheduling'] == "preemptible"
+    assert nodes_cfg['misc']['node_name'] == "my-node"
+    assert nodes_cfg['misc']['tags'] == "tag1,tag2,tag3"


### PR DESCRIPTION
… the nodes section for gce

This should fix issue #381. The issue was coming from the fact that cloud specific parameters in the config files weren't passed to the Node instances.