### PR TITLE
Initial Keystone v3 support

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -287,6 +287,20 @@ Valid configuration keys for *openstack*
     starts, the config option will be ignored and the value of the
     variable will be used instead.
 
+``project_domain_name``
+
+    OpenStack project domain. If an
+    environment variable `OS_PROJECT_DOMAIN_NAME` is set when
+    elasticluster starts, the config option will be ignored and the
+    value of the variable will be used instead.
+
+``user_domain_name``
+
+    OpenStack user domain. If an environment variable 
+    `OS_USER_DOMAIN_NAME` is set when elasticluster starts, the
+    config option will be ignored and the value of the variable will
+    be used instead.
+
 ``region_name``
 
     OpenStack region (optional)

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -180,6 +180,8 @@ CLOUD_PROVIDER_SCHEMAS = {
         Optional("auth_url", default=os.getenv('OS_AUTH_URL', '')): url,
         Optional("username", default=os.getenv('OS_USERNAME', '')): nonempty_str,
         Optional("password", default=os.getenv('OS_PASSWORD', '')): nonempty_str,
+        Optional("user_domain_id", default=os.getenv('OS_USER_DOMAIN_NAME', '')): nonempty_str,
+        Optional("project_domain_id", default=os.getenv('OS_PROJECT_DOMAIN_NAME', '')): nonempty_str,
         Optional("project_name",
                  # if OS_PROJECT_NAME is not defined,
                  # try legacy variable OS_TENANT_NAME as a fallback

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -180,8 +180,8 @@ CLOUD_PROVIDER_SCHEMAS = {
         Optional("auth_url", default=os.getenv('OS_AUTH_URL', '')): url,
         Optional("username", default=os.getenv('OS_USERNAME', '')): nonempty_str,
         Optional("password", default=os.getenv('OS_PASSWORD', '')): nonempty_str,
-        Optional("user_domain_id", default=os.getenv('OS_USER_DOMAIN_NAME', '')): nonempty_str,
-        Optional("project_domain_id", default=os.getenv('OS_PROJECT_DOMAIN_NAME', '')): nonempty_str,
+        Optional("user_domain_name", default=os.getenv('OS_USER_DOMAIN_NAME', '')): nonempty_str,
+        Optional("project_domain_name", default=os.getenv('OS_PROJECT_DOMAIN_NAME', '')): nonempty_str,
         Optional("project_name",
                  # if OS_PROJECT_NAME is not defined,
                  # try legacy variable OS_TENANT_NAME as a fallback

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -64,8 +64,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
     :param str username: username of the keystone user
     :param str password: password of the keystone user
     :param str project_name: name of the project to use
-    :param str user_domain_id: name of the user domain to use
-    :param str project_domain_id: name of the project domain to use
+    :param str user_domain_name: name of the user domain to use
+    :param str project_domain_name: name of the project domain to use
     :param str auth_url: url of keystone endpoint
     :param str region: OpenStack region to use
     :param str storage_path: path to store temporary data
@@ -77,7 +77,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
     __node_start_lock = threading.Lock()  # lock used for node startup
 
     def __init__(self, username, password, project_name, auth_url,
-                 user_domain_id, project_domain_id,
+                 user_domain_name, project_domain_name,
                  region_name=None, storage_path=None,
                  request_floating_ip=False,
                  nova_api_version=DEFAULT_OS_NOVA_API_VERSION):
@@ -85,8 +85,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self._os_username = os.getenv('OS_USERNAME', username)
         self._os_password = os.getenv('OS_PASSWORD', password)
         self._os_tenant_name = os.getenv('OS_TENANT_NAME', project_name)
-        self._os_project_domain_id = os.getenv('OS_PROJECT_DOMAIN_NAME', project_domain_id)
-        self._os_user_domain_id = os.getenv('OS_USER_DOMAIN_NAME', user_domain_id)
+        self._os_project_domain_name = os.getenv('OS_PROJECT_DOMAIN_NAME', project_domain_name)
+        self._os_user_domain_name = os.getenv('OS_USER_DOMAIN_NAME', user_domain_name)
         self._os_region_name = region_name
         self.request_floating_ip = request_floating_ip
         self.nova_api_version = nova_api_version
@@ -97,8 +97,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         auth = loader.load_from_options(auth_url=self._os_auth_url,
                                         username=self._os_username,
                                         password=self._os_password,
-                                        user_domain_id=self._os_user_domain_id,
-                                        project_domain_id=self._os_project_domain_id,
+                                        user_domain_name=self._os_user_domain_name,
+                                        project_domain_name=self._os_project_domain_name,
                                         project_name=self._os_tenant_name)
         sess = session.Session(auth=auth)
         self.client = client.Client(self.nova_api_version, session=sess)
@@ -391,8 +391,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 'username': self._os_username,
                 'password': self._os_password,
                 'project_name': self._os_tenant_name,
-                'project_domain_id': self._os_project_domain_id,
-                'user_domain_id': self._os_user_domain_id,
+                'project_domain_name': self._os_project_domain_name,
+                'user_domain_name': self._os_user_domain_name,
                 'region_name': self._os_region_name,
                 'request_floating_ip': self.request_floating_ip,
                 'instance_ids': self._instances.keys(),
@@ -404,14 +404,14 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self._os_username = state['username']
         self._os_password = state['password']
         self._os_tenant_name = state['project_name']
-        self._os_user_domain_id = state['user_domain_id']
-        self._os_project_domain_id = state['project)domain_id']
+        self._os_user_domain_name = state['user_domain_name']
+        self._os_project_domain_name = state['project)domain_name']
         self._os_region_name = state['region_name']
         self.request_floating_ip = state['request_floating_ip']
         self.nova_api_version = state.get('nova_api_version', DEFAULT_OS_NOVA_API_VERSION)
         self.client = client.Client(self.nova_api_version,
                                     self._os_username, self._os_password, self._os_tenant_name,
-                                    self._os_user_domain_id, self._os_project_domain_id,
+                                    self._os_user_domain_name, self._os_project_domain_name,
                                     self._os_auth_url, region_name=self._os_region_name)
         self._instances = {}
         self._cached_instances = {}

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -186,9 +186,9 @@ ec2_region=nova
 # request_floating_ip=False
 
 # Hobbes cloud, using the `openstack` provider
-# [cloud/hobbes]
-# provider=openstack
-# auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
+[cloud/hobbes]
+provider=openstack
+auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
 # domain_name=Default
 # username=***REPLACE WITH YOUR USERNAME (OS_USERNAME)***
 # password=***REPLACE WITH YOUR PASSWORD (OS_PASSWORD)***

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -186,12 +186,14 @@ ec2_region=nova
 # request_floating_ip=False
 
 # Hobbes cloud, using the `openstack` provider
-#[cloud/hobbes]
-#provider=openstack
-#auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
-#domain_name=Default
+# [cloud/hobbes]
+# provider=openstack
+# auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
+# domain_name=Default
 # username=***REPLACE WITH YOUR USERNAME (OS_USERNAME)***
 # password=***REPLACE WITH YOUR PASSWORD (OS_PASSWORD)***
+# project_domain_name=***REPLACE WITH YOUR PROJECT DOMAIN (OS_PROJECT_DOMAIN_NAME)***
+# project_user_name=***REPLACE WITH YOUR USER DOMAIN (OS_PROJECT_USER_NAME)***  
 # project_name=***REPLACE WITH YOUR PROJECT NAME (OS_TENANT_NAME)***
 # request_floating_ip=False
 # region_name=

--- a/elasticluster/share/etc/config.template
+++ b/elasticluster/share/etc/config.template
@@ -132,6 +132,14 @@
 #                    command. If an environment variable
 #                    `OS_TENANT_NAME` is set, this option is ignored.
 #
+# user_domain_id:    OpenStack user domain to use,
+#                    If an environment variable
+#                    `OS_USER_DOMAIN_NAME` is set, this option is ignored.
+#
+# project_domain_id: OpenStack project domain to use,
+#                    If an environment variable
+#                    `OS_PROJECT_DOMAIN_NAME` is set, this option is ignored.
+#
 # region_name:       OpenStack region (optional) 
 # request_floating_ip: request assignment of a floating IP when the
 #                      instance is started.
@@ -178,9 +186,10 @@ ec2_region=nova
 # request_floating_ip=False
 
 # Hobbes cloud, using the `openstack` provider
-[cloud/hobbes]
-provider=openstack
-auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
+#[cloud/hobbes]
+#provider=openstack
+#auth_url=http://hobbes.gc3.uzh.ch:5000/v2.0
+#domain_name=Default
 # username=***REPLACE WITH YOUR USERNAME (OS_USERNAME)***
 # password=***REPLACE WITH YOUR PASSWORD (OS_PASSWORD)***
 # project_name=***REPLACE WITH YOUR PROJECT NAME (OS_TENANT_NAME)***

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ elif python_version == (2, 7):
         # Novaclient 8.0.0 changed some API again, see issue #425
         # FIXME: need to fix this at source level rather than blacklisting
         'python-novaclient<8.0.0',
+        'python-keystoneclient<3.10.0',
     ]
 else:
     raise RuntimeError("ElastiCluster requires Python 2.6 or 2.7")

--- a/tests/_helpers/config.py
+++ b/tests/_helpers/config.py
@@ -53,6 +53,8 @@ provider = openstack
 auth_url = http://openstack.example.com:5000/v2.0
 username = ${USER}
 password = XXXXXX
+project_domain_id = Default
+user_domain_id = Default
 tenant_name = test-tenant
         """,
 
@@ -241,10 +243,12 @@ _CONFIG_KV = {
         },
         "example_openstack": {
             "cloud": {
-                "auth_url": "http://openstack.example.com:5000/v2.0",
+                "auth_url": "http://openstack.example.com:35357",
                 "password": "XXXXXX",
                 "project_name": "test-tenant",
                 "provider": "openstack",
+                "project_domain_id": "Default",
+                "user_domain_id": "Default",
                 "username": "rmurri"
             },
             "compute_nodes": "2",
@@ -360,9 +364,11 @@ class Configuration(object):
                     },
                 "cloud": {
                     "provider": "openstack",
-                    "auth_url": "http://cloud.gc3.uzh.ch:5000/v2.0",
+                    "auth_url": "http://cloud.gc3.uzh.ch:35357",
                     "username": "myusername",
                     "password": "mypassword",
+                    "project_domain_id": "Default",
+                    "user_domain_id": "Default",
                     "project_name": "myproject",
                     },
                 "login": {


### PR DESCRIPTION
The implements keystone v3 support but I'm not clear if it breaks support for keystone v2 only environments. I suspect it may as keystone v2 cannot handle the two new variables. Unfortunately I have no v2 only environments to test this on. Perhaps this can be used as a starting point?

Alternative would perhaps be to implement another openstack provider for keystone v3 (a bit nasty) or detect API version in the current openstack provider, probably using environmental variable OS_IDENTITY_API_VERSION

