### PR TITLE
Align requests version requirement with what msrest specifies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
         # OpenStack clouds
         'netifaces',
         'apache-libcloud',
-        'requests!=2.13.0,!=2.12.2,>=2.10.0',  ## see issue #414
+        'requests~=2.14.1',  ## see issue #441
         #'python-novaclient' ## this needs special treatment depending on Python version, see below
     ] + version_dependent_requires),
     tests_require=['tox', 'mock', 'pytest>=2.10'],  # read right-to-left


### PR DESCRIPTION
`pip` was installing `2.17.3` `requests`, whereas `msrest` needs `2.14.1`.

This addresses issue #441 