### PR TITLE
Changes to use SLURM 17.02 RPMs from my COPR repo

### DIFF
--- a/elasticluster/share/playbooks/roles/slurm-client/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/slurm-client/tasks/main.yml
@@ -52,8 +52,7 @@
     - slurm
     - slurm-devel
     - slurm-perlapi
-    - slurm-sjobexit
-    - slurm-sjstat
+    - slurm-contribs
     - slurm-torque
   when: 'is_rhel_compatible'
 

--- a/elasticluster/share/playbooks/roles/slurm-common/templates/copr-slurm.repo.j2
+++ b/elasticluster/share/playbooks/roles/slurm-common/templates/copr-slurm.repo.j2
@@ -6,9 +6,9 @@
 # see: https://copr.fedorainfracloud.org/coprs/verdurin/slurm/
 [verdurin-slurm]
 name=Copr repo for SLURM owned by verdurin
-baseurl=https://copr-be.cloud.fedoraproject.org/results/verdurin/slurm/epel-{{ansible_distribution_major_version}}-$basearch/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/verdurin/slurm-17.02/epel-{{ansible_distribution_major_version}}-$basearch/
 skip_if_unavailable=True
 gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/verdurin/slurm/pubkey.gpg
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/verdurin/slurm-17.02/pubkey.gpg
 enabled=1
 enabled_metadata=1

--- a/elasticluster/share/playbooks/roles/slurm-master/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/slurm-master/tasks/init-RedHat.yml
@@ -6,7 +6,6 @@
     slurmctld_packages:
       - mailx
       - slurm-plugins
-      - slurm-slurmdb-direct
       - slurm
     slurmdbd_service_name: slurmdbd
     slurmdbd_packages:
@@ -22,7 +21,6 @@
     slurmctld_packages:
       - mailx
       - slurm-plugins
-      - slurm-slurmdb-direct
       - slurm
     slurmdbd_service_name: slurmdbd
     slurmdbd_packages:


### PR DESCRIPTION
Use the SLURM 17.02 RPMs and adjust playbooks to handle the changes in which RPMs are provided.