### PR TITLE
WIP: OpenStack: allocate floating IPs using Neutron API.

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -451,14 +451,7 @@ Valid configuration keys for ``openstack``
   the environment variable is used instead.
 
 ``request_floating_ip``
-  request assignment of a "floating IP" when the instance is
-  started. Valid values are ``yes`` (or ``True`` or ``1``) and ``no``
-  (or ``False`` or ``0``; default).  Some cloud providers do not
-  automatically assign a public IP to the instances, but this is often
-  needed if you want to connect to the VM from outside. Setting
-  ``request_floating_ip`` to ``yes`` will force `elasticluster` to
-  request such a floating IP if the instance doesn't get one
-  automatically.
+  **See ``request_floating_ip`` in the ``[cluster/...]`` section instead.**
 
 
 Examples
@@ -1170,6 +1163,20 @@ Additional optional configuration keys for OpenStack clouds
     Define the size of boot disk to use.  Values are specified in
     gigabytes.  There is no default; this option is mandatory of
     ``boot_disk_type`` is also specified.
+
+``floating_network_id``
+    If ``request_floating_ip`` (which see below) is true, then
+    request that the floating IP be allocated on this network.
+
+``request_floating_ip``
+    Request assignment of a "floating IP" when the instance is
+    started. Valid values are ``yes`` (or ``True`` or ``1``) and
+    ``no`` (or ``False`` or ``0``; default).  Some cloud providers do
+    not automatically assign a public IP to the instances, but this is
+    often needed if you want to connect to the VM from
+    outside. Setting ``request_floating_ip`` to ``yes`` will force
+    ElastiCluster to request such a floating IP if the instance
+    doesn't get one automatically.
 
 
 Examples

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -1393,7 +1393,9 @@ class Node(Struct):
         for ip in itertools.chain([self.preferred_ip], ips):
             if not ip:
                 continue
-            log.debug("Trying to connect to host %s (%s) ...", self.name, ip)
+            log.debug(
+                "Trying to connect to host %s using IP address %s ...",
+                self.name, ip)
             try:
                 addr, port = parse_ip_address_and_port(ip, SSH_PORT)
                 extra = {

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -122,6 +122,7 @@ SCHEMA = {
                 Optional("min_cpu_platform"): nonempty_str,
                 # only on OpenStack
                 Optional('floating_network_id'): str,
+                Optional("request_floating_ip"): boolean,
                 # allow other string keys w/out restrictions
                 Optional(str): str,
             },
@@ -138,6 +139,7 @@ SCHEMA = {
         Optional("min_cpu_platform"): nonempty_str,
         # only on OpenStack
         Optional('floating_network_id'): str,
+        Optional("request_floating_ip"): boolean,
         # allow other string keys w/out restrictions
         Optional(str): str,
     },
@@ -219,15 +221,14 @@ CLOUD_PROVIDER_SCHEMAS = {
         Optional("user_domain_name"): nonempty_str,
         Optional("project_domain_name"): nonempty_str,
         Optional("project_name"): nonempty_str,
-        Optional("request_floating_ip"): boolean,
+        Optional("request_floating_ip"): boolean,  ## DEPRECATED, place in cluster or node config
         Optional("region_name"): nonempty_str,
         Optional("compute_api_version"): Or('1.1', '2'),
         Optional("image_api_version"): Or('1', '2'),
         Optional("network_api_version"): Or('2.0'),
         Optional("volume_api_version"): Or('1', '2', '3'),
         Optional("identity_api_version"): Or('3', '2'),  # no default, can auto-detect
-        ## DEPRECATED, use `compute_api_version` instead
-        Optional("nova_api_version"): nova_api_version,
+        Optional("nova_api_version"): nova_api_version,  ## DEPRECATED, use `compute_api_version` instead
     },
 
     'libcloud': {
@@ -688,6 +689,7 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
             'tags'
             # OpenStack only
             'floating_network_id',
+            'request_floating_ip',
             #'user_key_name',    ## from `login/*`
             #'user_key_private', ## from `login/*`
             #'user_key_public',  ## from `login/*`

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -120,6 +120,8 @@ SCHEMA = {
                 Optional("local_ssd_count", default=0): nonnegative_int,
                 Optional("local_ssd_interface", default='SCSI'): Or('NVME', 'SCSI'),
                 Optional("min_cpu_platform"): nonempty_str,
+                # only on OpenStack
+                Optional('floating_network_id'): str,
                 # allow other string keys w/out restrictions
                 Optional(str): str,
             },
@@ -134,6 +136,8 @@ SCHEMA = {
         Optional("local_ssd_count", default=0): nonnegative_int,
         Optional("local_ssd_interface", default='SCSI'): Or('NVME', 'SCSI'),
         Optional("min_cpu_platform"): nonempty_str,
+        # only on OpenStack
+        Optional('floating_network_id'): str,
         # allow other string keys w/out restrictions
         Optional(str): str,
     },
@@ -682,6 +686,8 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
             'min_cpu_platform',
             'scheduling',
             'tags'
+            # OpenStack only
+            'floating_network_id',
             #'user_key_name',    ## from `login/*`
             #'user_key_private', ## from `login/*`
             #'user_key_public',  ## from `login/*`

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -19,15 +19,16 @@ Cloud provider for the Google Compute Engine.
 
 See <https://code.google.com/p/google-cloud-platform-samples/source/browse/python-client-library-example/gce.py?repo=compute> for reference.
 """
-__author__ = 'Riccardo Murri <riccardo.murri@uzh.ch>, ' \
-             'Nicolas Baer <nicolas.baer@gmail.com>, '  \
-             'Antonio Messina <antonio.s.messina@gmail.com>'
+__author__ = ', '.join([
+    'Riccardo Murri <riccardo.murri@uzh.ch>',
+    'Nicolas Baer <nicolas.baer@gmail.com>',
+    'Antonio Messina <antonio.s.messina@gmail.com>'
+])
 
 
 # stdlib imports
 import collections
 import copy
-import httplib2
 import os
 import random
 import threading
@@ -39,6 +40,7 @@ import uuid
 from apiclient.discovery import build
 from apiclient.errors import HttpError
 import googleapiclient
+import httplib2
 from oauth2client.file import Storage
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.client import GoogleCredentials


### PR DESCRIPTION
The equivalent functionality in Compute API (Nova) has been
deprecated.

Fixes #496