### PR TITLE
Bigtop installation fix (and question about spark-thriftserver crash)

### DIFF
--- a/elasticluster/share/playbooks/roles/bigtop/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/bigtop/defaults/main.yml
@@ -2,7 +2,7 @@
 ---
 
 # What release of Apache Bigtop to get packages from
-bigtop_release: '1.1.0'
+bigtop_release: '1.2.1'
 
 # identifier for GnuPG key(s) used to sign packages from the Apache Bigtop repo
 bigtop_signing_key:

--- a/elasticluster/share/playbooks/roles/bigtop/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/bigtop/defaults/main.yml
@@ -3,8 +3,3 @@
 
 # What release of Apache Bigtop to get packages from
 bigtop_release: '1.2.1'
-
-# identifier for GnuPG key(s) used to sign packages from the Apache Bigtop repo
-bigtop_signing_key:
-  - '13971DA39475BD5D'
-  - '3A367EA0FA08B173'

--- a/elasticluster/share/playbooks/roles/bigtop/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/bigtop/tasks/main.yml
@@ -8,15 +8,14 @@
   
 - name: add signing key for Apache Bigtop repository
   apt_key:
-    keyserver=keys.gnupg.net
-    id='{{item}}'
-  with_items: '{{bigtop_signing_key}}'
+    url: "http://www.apache.org/dist/bigtop/bigtop-{{ bigtop_release }}/repos/GPG-KEY-bigtop"
+    state: present
 
   
 - name: add Apache Bigtop repository
   apt_repository:
-    # download from: http://www.apache.org/dist/bigtop/bigtop-1.0.0/repos/trusty/bigtop.list
-    repo='deb http://bigtop-repos.s3.amazonaws.com/releases/{{bigtop_release}}/{{ansible_distribution|lower}}/{{ansible_distribution_major_version}}/x86_64 bigtop contrib'
+    # download from: http://www.apache.org/dist/bigtop/bigtop-1.2.1/repos/ubuntu16.04/bigtop.list
+    repo='deb http://repos.bigtop.apache.org/releases/{{bigtop_release}}/{{ansible_distribution|lower}}/{{ansible_distribution_version}}/x86_64 bigtop contrib'
     state=present
 
 


### PR DESCRIPTION
I am testing the hadoop+spark setup using ubuntu 16.04. During my first test the bigtop installation was failing so I updated the role to install latest bigtop 1.2.1. This PR includes the modifications I did to install latest bigtop-1.2.1 in ubuntu 16.04

After this change elasticluster goes forward until it crashes in `TASK [spark-common : Install Spark packages (common)]` . It fails trying to start the `spark-thriftserver` service. This is what I get in `/var/log/spark/spark-thriftserver.out` in master node where the service doesn't start:

```
18/01/02 17:01:58 WARN metastore.HiveMetaStore: Retrying creating default database after error: Error creating transactional connection factory
javax.jdo.JDOFatalInternalException: Error creating transactional connection factory
```
```
Caused by: org.datanucleus.exceptions.NucleusException: Attempt to invoke the "BONECP" plugin to create a ConnectionPool gave an error : The specified datastore driver ("org.postgresql.Driver") was not found in the CLASSPATH. Please check your CLASSPATH specification, and the name of the driver.
```

I have checked that deb package `libpostgresql-jdbc-java` is installed in the machine. 

I have no experience with Spark, does anyone knows why this could be failing? Any suggestion about how to fix it? I can try to fix the playbooks but I am not sure how the elasticluster developers would prefer to approach this so I prefer to ask before I do more modifications to try to do a fix which can be merged upstream.
