### PR TITLE
SecretStorage requires python 3.5 since 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ elif python_version == (2, 7):
         'ipaddress',
         'pathlib2',
         'scandir',
-        'secretstorage',
+        'secretstorage<=2.3.1',
     ]
 else:
     raise RuntimeError("ElastiCluster requires Python 2.6 or 2.7")


### PR DESCRIPTION
Python 3.5 or newer is now required since 3.0.0 for secret storage[1]
So contraint it to the latest supported version 2.3.1 for python2.7

[1]:
http://secretstorage.readthedocs.io/en/latest/changelog.html#secretstorage-3-0-0-2018-04-23