### PR TITLE
Upper contraint novaclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ elif python_version == (2, 7):
         'python-glanceclient',
         'python-neutronclient',
         'python-cinderclient',
-        'python-novaclient',
+        'python-novaclient<=9.1.2',
         # fix dependency conflict among OpenStack libraries:
         # `osc-lib` has a more strict dependency specifier
         # which is not picked up by `pip` because it's not


### PR DESCRIPTION
floating-ip-associate was removed from novaclient from version
10.0.0 [1], constraint version to 9.1.2 for now

[1]:
https://github.com/openstack/python-novaclient/commit/01fb16533bf562f39fe822bc12b9cc34b8580359#diff-195f8259a919a0b9126b2271fc1a435d