### PR TITLE
Introduce floating_network_id for openstack floating ip allocate

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -109,6 +109,7 @@ SCHEMA = {
                 Optional('image_userdata', default=''): str,
                 Optional('security_group', default='default'): str,  ## FIXME: alphanumeric?
                 Optional('network_ids'): str,
+                Optional('floating_network_id'): str,
                 # these are auto-generated but already there by the time
                 # validation is run
                 'login': nonempty_str,
@@ -665,6 +666,7 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
             'image_userdata',
             'login',
             'network_ids',
+            'floating_network_id',
             'security_group',
             'node_name',
             'ssh_proxy_command',

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ elif python_version == (2, 7):
         'ipaddress',
         'pathlib2',
         'scandir',
-        'secretstorage',
+        'secretstorage<=2.3.1',
     ]
 else:
     raise RuntimeError("ElastiCluster requires Python 2.6 or 2.7")


### PR DESCRIPTION
and fix some issues related with floating ip for openstack provider:
- neutron_client.list_floatingips returns a dictionary like:
   `{"floatingips": ...}`
- neutron_client.create_floatingip returns a dictionary like:
   `{"floatingip": ...}`
- novaclient.server.add_floating_ip accepts an IP address as parameter not a dictionary