### PR TITLE
add tag to filter tasks related to glusterfs mountpoint

### DIFF
--- a/elasticluster/share/playbooks/roles/glusterfs-client/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/glusterfs-client/tasks/main.yml
@@ -18,6 +18,7 @@
   tags:
       - gluster
       - glusterfs-client
+      - glusterfs-client-mount
 
 
 - name: Mount GlusterFS filesystem {{item.mountpoint}}
@@ -31,3 +32,4 @@
   tags:
       - gluster
       - glusterfs-client
+      - glusterfs-client-mount


### PR DESCRIPTION
In this way, we can setup a node as glusterfs-client without the need to Mount GlusterFS filesystem at the same time.
