### PR TITLE
Hpc-extra - new playbook

### DIFF
--- a/elasticluster/share/playbooks/roles/hpc-common/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/hpc-common/tasks/init-RedHat.yml
@@ -9,6 +9,7 @@
       - gcc-gfortran
       - hdf5
       - hdf5-openmpi
+      - hdf5-openmpi-devel
       - make
       - netcdf-devel
       - openmpi

--- a/elasticluster/share/playbooks/roles/hpc-common/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/hpc-common/tasks/init-RedHat.yml
@@ -13,3 +13,5 @@
       - netcdf-devel
       - openmpi
       - openmpi-devel
+      - openmpi3
+      - openmpi3-devel

--- a/elasticluster/share/playbooks/roles/hpc-common/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/hpc-common/tasks/main.yml
@@ -27,3 +27,9 @@
     dest: '/etc/modulefiles/Core/mpi/openmpi.lua'
     src: 'etc/modulefiles/Core/mpi/openmpi.lua.j2'
     mode: 0444
+
+- name: Deploy OpenMPI3 environment module
+  template:
+    dest: '/etc/modulefiles/Core/mpi/openmpi3.lua'
+    src: 'etc/modulefiles/Core/mpi/openmpi3.lua.j2'
+    mode: 0444

--- a/elasticluster/share/playbooks/roles/hpc-common/templates/etc/modulefiles/Core/mpi/openmpi3.lua.j2
+++ b/elasticluster/share/playbooks/roles/hpc-common/templates/etc/modulefiles/Core/mpi/openmpi3.lua.j2
@@ -1,0 +1,58 @@
+--
+-- THIS FILE IS CONTROLLED BY ELASTICLUSTER
+-- local modifications will be overwritten
+-- the next time `elasticluster setup` is run!
+--
+
+--
+-- OpenMPI module for use with 'environment-modules' package
+--
+help([[
+Load the version of OpenMPI3 that came with the base OS.
+
+Note that it is configured (via env. variables) to use TCP sockets for
+message passing, and avoid even probing for IB.
+
+To find out more about OpenMPI, visit: http://www.open-mpi.org/
+]])
+whatis("Load the version of OpenMPI3 that came with the base OS.")
+
+-- no two MPI packages can be loaded at the same time
+family("MPI")
+
+{% if ansible_os_family == 'Debian' -%}
+-- (e.g. the Python `openmpi` package) were removed.
+-- NOTE: I've not found openmpi3 for debian like as a separate package;
+-- This hasn't been tested!
+--
+{%- elif ansible_os_family == 'RedHat' -%}
+prepend_path("PATH", 	        "/usr/lib64/openmpi3/bin")
+prepend_path("LD_LIBRARY_PATH", "/usr/lib64/openmpi3/lib")
+prepend_path("INCLUDE_PATH", "/usr/include/openmpi3-x86_64")
+prepend_path("PYTHONPATH",      "/usr/lib64/python2.7/site-packages/openmpi3")
+prepend_path("MANPATH",         "/usr/share/man/openmpi3-x86_64")
+setenv("MPI_BIN",		"/usr/lib64/openmpi3/bin")
+setenv("MPI_SYSCONFIG",	        "/etc/openmpi3-x86_64")
+setenv("MPI_FORTRAN_MOD_DIR",	"/usr/lib64/gfortran/modules/openmpi3")
+setenv("MPI_INCLUDE",	        "/usr/include/openmpi3-x86_64")
+setenv("MPI_LIB",	        "/usr/lib64/openmpi3/lib")
+setenv("MPI_MAN",	        "/usr/share/man/openmpi3-x86_64")
+setenv("MPI_PYTHON_SITEARCH",	"/usr/lib64/python2.7/site-packages/openmpi3")
+setenv("MPI_COMPILER",		"openmpi3-x86_64")
+setenv("MPI_SUFFIX",	        "_openmpi")
+setenv("MPI_HOME",	        "/usr/lib64/openmpi3")
+{%- else -%}
+LmodError("ElastiCluster lacks support for this base OS in its `openmpi3.lua` template.")
+{%- endif %}
+
+
+-- settings below this line are dependent solely on OpenMPI and not on the base OS
+
+-- it's unlikely there's Infiniband on cloud-based VMs,
+-- so disable it by default to avoid confusing warning
+-- messages from OpenMPI
+setenv("OMPI_MCA_btl", "self,sm,tcp")
+
+-- do not busy-wait while running MPI barriers; has a little impact on
+-- performance but saves money and energy on cloud "CPU burstable" instances
+setenv("OMPI_MCA_mpi_yield_when_idle", "1")

--- a/elasticluster/share/playbooks/roles/hpc-extra/meta/main.yml
+++ b/elasticluster/share/playbooks/roles/hpc-extra/meta/main.yml
@@ -1,5 +1,5 @@
+# hpc-extra/meta/main.yml
 ---
 
 dependencies:
   - role: hpc-common
-  - role: hpc-extra

--- a/elasticluster/share/playbooks/roles/hpc-extra/tasks/init-Debian.yml
+++ b/elasticluster/share/playbooks/roles/hpc-extra/tasks/init-Debian.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Load distribution-specific defaults (Debian/Ubuntu)
+  set_fact:
+    hpc_common_packages:
+      - build-essential
+      - gfortran
+      - libatlas-dev
+      - libhdf5-dev
+      - libhdf5-openmpi-dev
+      - libnetcdf-dev
+      - libopenmpi-dev
+      - openmpi-bin
+      - sqlite3

--- a/elasticluster/share/playbooks/roles/hpc-extra/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/hpc-extra/tasks/init-RedHat.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Load distribution-specific defaults (CentOS/RHEL)
+  set_fact:
+    hpc_extra_packages:
+      - centos-release-scl
+      - devtoolset-7
+      - devtoolset-7-gcc-c++
+      - devtoolset-7-gcc-gfortran
+      - cmake3
+      - automake
+      - autoconf
+      - tmux
+      - git
+      - wget
+      - libgomp
+      - gmp-devel
+      - mpfr-devel
+      - hdf5-devel
+      - fftw-devel
+      - eigen3-devel
+      - lapack64-devel
+      - lapack-devel
+      - numactl-libs

--- a/elasticluster/share/playbooks/roles/hpc-extra/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/hpc-extra/tasks/main.yml
@@ -1,0 +1,29 @@
+# hpc-extra/tasks/main.yml
+---
+
+- name: Load distribution-specific parameters
+  include: 'init-{{ansible_os_family}}.yml'
+
+
+- name: Install extra HPC software
+  package:
+    name: '{{item}}'
+    state: '{{ pkg_install_state }}'
+  with_items: '{{hpc_extra_packages}}'
+
+
+- name: Ensure modulefiles directories exist
+  file:
+    dest: '{{item}}'
+    state: directory
+  with_items:
+    - '/etc/modulefiles'
+    - '/etc/modulefiles/Core'
+    - '/etc/modulefiles/Core/compilers'
+
+
+- name: Deploy GCC7 environment module
+  template:
+    dest: '/etc/modulefiles/Core/compilers/gcc7.lua'
+    src: 'etc/modulefiles/Core/compilers/gcc7.lua.j2'
+    mode: 0444

--- a/elasticluster/share/playbooks/roles/hpc-extra/templates/etc/modulefiles/Core/compilers/gcc7.lua.j2
+++ b/elasticluster/share/playbooks/roles/hpc-extra/templates/etc/modulefiles/Core/compilers/gcc7.lua.j2
@@ -1,0 +1,28 @@
+--
+-- THIS FILE IS CONTROLLED BY ELASTICLUSTER
+-- local modifications will be overwritten
+-- the next time `elasticluster setup` is run!
+--
+
+--
+-- gcc7 module for use with 'environment-modules' package
+--
+help([[
+Load the version 7 of gnu compilers.
+]])
+whatis("Load the version 7 of gnu compilers.")
+
+-- no two MPI packages can be loaded at the same time
+family("compilers")
+
+{% if ansible_os_family == 'Debian' -%}
+-- TODO {# this needs to do #}
+LmodError("ElastiCluster lacks support for this base OS in its `gcc.lua` template.")
+
+{%- elif ansible_os_family == 'RedHat' -%}
+prepend_path("PATH", 	        "/opt/rh/devtoolset-7/root/usr/bin")
+prepend_path("LD_LIBRARY_PATH", "/opt/rh/devtoolset-7/root/usr/lib64:/opt/rh/devtoolset-7/root/usr/lib")
+prepend_path("MANPATH",         "/opt/rh/devtoolset-7/root/usr/share/man")
+{%- else -%}
+LmodError("ElastiCluster lacks support for this base OS in its `gcc.lua` template.")
+{%- endif %}


### PR DESCRIPTION
I'm not sure whether this is the way to add new playbooks. But since I've done it and it adds a couple of dependencies I needed I believe it's better to share it with whoever may need it.

This adds a new module on openMPI3 for centos7 to `hpc-common` and a new playbook: `hpc-extra`. Maybe this type of setup would be better to do via easy-build?

I'm happy for this to be closed if this is not the right way to do this.
