### PR TITLE
Pre-emptible instances cannot be automatically restarted

### DIFF
--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -440,6 +440,9 @@ class GoogleCloudProvider(AbstractCloudProvider):
             # see: https://cloud.google.com/compute/docs/gpus#restrictions
             instance['scheduling']['onHostMaintenance'] = 'TERMINATE'
             instance['scheduling']['automaticRestart'] = True
+            if scheduling_option['preemptible']:
+                # preemptible instance cannot be restarted automatically
+                instance['scheduling']['automaticRestart'] = False
 
         # create the instance
         gce = self._connect()

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -440,9 +440,10 @@ class GoogleCloudProvider(AbstractCloudProvider):
             # see: https://cloud.google.com/compute/docs/gpus#restrictions
             instance['scheduling']['onHostMaintenance'] = 'TERMINATE'
             instance['scheduling']['automaticRestart'] = True
-            if scheduling_option['preemptible']:
-                # preemptible instance cannot be restarted automatically
-                instance['scheduling']['automaticRestart'] = False
+
+        # preemptible instance cannot be restarted automatically
+        if scheduling_option['preemptible']:
+            instance['scheduling']['automaticRestart'] = False
 
         # create the instance
         gce = self._connect()


### PR DESCRIPTION
From the doc: https://cloud.google.com/compute/docs/instances/preemptible
"Preemptible instances cannot live migrate or be set to automatically restart when there is a maintenance event."
Since the state of "when there is a maintenance event" cannot be known at instance creation, I guess the best is to set automaticRestart to False when preemptible.
(GCE always rejected by instance creation when automaticRestart=True and preemptible=True anyway)
