### PR TITLE
Openstack: support for anti-affinity server groups.

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -222,6 +222,7 @@ CLOUD_PROVIDER_SCHEMAS = {
         Optional("network_api_version"): Or('2.0'),
         Optional("volume_api_version"): Or('1', '2', '3'),
         Optional("identity_api_version"): Or('3', '2'),  # no default, can auto-detect
+        Optional("anti_affinity_group_prefix"): nonempty_str,
         ## DEPRECATED, use `compute_api_version` instead
         Optional("nova_api_version"): nova_api_version,
     },

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -129,6 +129,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         or `None` (default, meaning try v3 first and fall-back to v2).
     :param cacert: Path to CA certificate bundle (for verifying HTTPS sessions)
         or ``None`` to use the systems' default.
+    :param bool manage_anti_affinity_groups: use openstack aaf to spread the load
+    :param str anti_affinity_group_prefix: prefix for creating server groups
     """
 
     __node_start_lock = threading.Lock()
@@ -149,6 +151,8 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                  # this is deprecated in favor of `compute_api_version`
                  nova_api_version=None,
                  cacert=None,  # keep in sync w/ default in novaclient.Client()
+                 manage_anti_affinity_groups=False,
+                 anti_affinity_group_prefix=None
     ):
         # OpenStack connection params
         self._os_auth_url = self._get_os_config_value('auth URL', auth_url, ['OS_AUTH_URL']).rstrip('/')
@@ -188,6 +192,10 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self.request_floating_ip = request_floating_ip
         self._instances = {}
         self._cached_instances = {}
+
+        self.anti_affinity_group_prefix = anti_affinity_group_prefix
+        # constant for anti-affinity routines.
+        self.middle_token = ".number."
 
     @staticmethod
     def _get_os_config_value(thing, value, varnames, default=_NO_DEFAULT):
@@ -499,10 +507,38 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                         .format(id=volume.id, delete_on_terminate=1)),
             }
 
-        # due to some `nova_client.servers.create()` implementation weirdness,
-        # the first three args need to be spelt out explicitly and cannot be
-        # conflated into `**vm_start_args`
-        vm = self.nova_client.servers.create(node_name, image_id, flavor, **vm_start_args)
+
+
+        out_of_capacity = 'No valid host was found. There are not enough hosts available.'
+
+        # create anti-affinity groups for spawning servers to ensure server spread
+        # equally across hosts in the cloud.
+        # This will create a server group, spawn hosts in the group until it's full
+        # and then create a new group.
+        if self.anti_affinity_group_prefix:
+            with OpenStackCloudProvider.__node_start_lock:
+
+                group = self._get_current_anti_affinity_group()
+                vm_start_args['scheduler_hints']={ 'group' : group.id }
+                vm = self.nova_client.servers.create(node_name, image_id, flavor, **vm_start_args)
+                self._wait_for_status(vm, ["ACTIVE", "ERROR"], 10)
+
+                if vm.status == 'ERROR' and vm.fault['message'] == out_of_capacity:
+                    log.debug("Deleting instance %s(%s) in group %s", vm.name, vm.id, group.name)
+                    self.nova_client.servers.delete(vm.id)
+
+                    group=self._get_next_anti_affinity_group()
+                    vm_start_args['scheduler_hints']={ 'group' : group.id }
+
+                    vm = self.nova_client.servers.create(node_name, image_id, flavor, **vm_start_args)
+
+                log.debug("Started server %s in group %s", vm.name, group.name)
+        else:
+            # due to some `nova_client.servers.create()` implementation weirdness,
+            # the first three args need to be spelt out explicitly and cannot be
+            # conflated into `**vm_start_args`
+            vm = self.nova_client.servers.create(node_name, image_id, flavor, **vm_start_args)
+
 
         # allocate and attach a floating IP, if requested
         if self.request_floating_ip:
@@ -529,6 +565,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self._init_os_api()
         instance = self._load_instance(instance_id)
         instance.delete()
+        self._delete_anti_affinity_groups()
         del self._instances[instance_id]
 
     def get_ips(self, instance_id):
@@ -554,6 +591,39 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         return instance.status == 'ACTIVE'
 
     # Protected methods
+
+    def _delete_anti_affinity_groups(self):
+        for group in self._list_anti_affinity_groups():
+            self.nova_client.server_groups.delete(group.id)
+
+    def _get_next_anti_affinity_group(self):
+        group_name=self._make_next_group_name(self._get_current_anti_affinity_group().name)
+        return self.nova_client.server_groups.create(name=group_name, policies='anti-affinity')
+
+    def _get_current_anti_affinity_group(self):
+        groups=self._list_anti_affinity_groups()
+
+        if groups:
+            group = sorted(groups, key=lambda g: g.name)[-1]
+        else:
+            group = self.nova_client.server_groups.create(name=self.anti_affinity_group_prefix + self.middle_token + "1", policies='anti-affinity')
+
+        return group
+
+    def _wait_for_status(self, vm, accepted_statuses, attempts):
+        for i in range(attempts):
+            vm.get()
+            if vm.status in accepted_statuses:
+                break
+            sleep(1)
+
+    def _make_next_group_name(self, current_name):
+            split_name=current_name.split('.')
+            split_name[-1]=str(int(split_name[-1])+1)
+            return '.'.join(split_name)
+
+    def _list_anti_affinity_groups(self):
+        return [  group for group in self.nova_client.server_groups.list() if self.anti_affinity_group_prefix + self.middle_token in group.name ]
 
     def _check_keypair(self, name, public_key_path, private_key_path):
         """First checks if the keypair is valid, then checks if the keypair


### PR DESCRIPTION
Hello,

We made this feature for one of our clients and interested if it would be welcomed upstream.

The goal is to provide better results for cpu hungry applications on openstack clouds with cpu overcommit.