### PR TITLE
Fix for issue reading floating IPs using the OpenStack Neutron client.

### DIFF
--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -512,7 +512,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 floating_ips = [ip for ip in self.nova_client.floating_ips.list()
                                 if ip.instance_id == vm.id]
             except AttributeError:
-                floating_ips = self.neutron_client.list_floatingips(id=vm.id)
+                floating_ips = self.neutron_client.list_floatingips(id=vm.id)['floatingips']
             # allocate new floating IP if none given
             if not floating_ips:
                 self._allocate_address(vm, network_ids)


### PR DESCRIPTION
There appears to be an issue with the code for listing floating IPs using the OpenStack Neutron client.  In elasticluster/providers/openstack.py, the code [`neutron_client.list_floatingips(id=vm.id)`](https://github.com/gc3-uzh-ch/elasticluster/blob/4d120121e7fec8a743570583176576c041e71c67/elasticluster/providers/openstack.py#L515) returns a dict containing an empty list.  The dict itself is still "truthy" so breaks the logic of the following branch.

The same list member deference is made elsewhere in the code when using the Neutron client.