### PR TITLE
Sergio: handle case where list ends with ','. Instead of creating an …

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -1075,7 +1075,7 @@ class Creator(object):
                 continue
             node_kind = key[:-len('_groups')]
             group_names = [group_name.strip()
-                           for group_name in value.split(',') if group_name.split()]
+                           for group_name in value.split(',') if group_name.strip()]
             for group_name in group_names:
                 # handle renames
                 if group_name in self._RENAMED_NODE_GROUPS:

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -1075,7 +1075,7 @@ class Creator(object):
                 continue
             node_kind = key[:-len('_groups')]
             group_names = [group_name.strip()
-                           for group_name in value.split(',')]
+                           for group_name in value.split(',') if group_name.split()]
             for group_name in group_names:
                 # handle renames
                 if group_name in self._RENAMED_NODE_GROUPS:


### PR DESCRIPTION
when `_groups` entry in config file has a leading `,` - e.g. 
`processing_groups = check-mk_agent, samba_client, anaconda, jupyterhub,`
elasticluster config creates a new inventory entry with empty role name.

expected behaviors:
either fails the config check or ignore, cleanup and continue.
I opt for the latter.
 