### PR TITLE
Docker playbook

### DIFF
--- a/elasticluster/share/playbooks/main.yml
+++ b/elasticluster/share/playbooks/main.yml
@@ -63,6 +63,7 @@
 - import_playbook: roles/r.yml
 - import_playbook: roles/rstudio.yml
 - import_playbook: roles/samba.yml
+- import_playbook: roles/docker.yml
 
 # Jupyter installation comes last, to allow it to pick up any SW that's been
 # installed so far (e.g., for kernels, or for ipyparallel)

--- a/elasticluster/share/playbooks/roles/docker-ce/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/docker-ce/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+docker_apt_release_channel: 'stable'
+
+# The URL of the apt repository.
+docker_apt_repository: 'deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}'
+
+# List of users that we want to add to the `docker` group.
+# We add at least the user running ansible and the current username (they may be different)
+docker_group_members:
+  - '{{ansible_user}}'

--- a/elasticluster/share/playbooks/roles/docker-ce/files/daemon.json
+++ b/elasticluster/share/playbooks/roles/docker-ce/files/daemon.json
@@ -1,0 +1,9 @@
+{
+  "experimental": true,
+  "icc": false,
+  "max-concurrent-downloads": 30,
+  "max-concurrent-uploads": 30,
+  "metrics-addr": "0.0.0.0:9102",
+  "storage-driver": "overlay2",
+  "userland-proxy": false
+}

--- a/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
@@ -6,15 +6,11 @@
 # 2) ca-certificates, a bundle of common certificate authorities' certificates
 - name: 'install docker dependencies'
   apt:
-    name: '{{ item }}'
-    state: 'present'
-  with_items:
-    - 'apt-transport-https'
-    - 'ca-certificates'
-  loop: '{{groups.docker_node}}'
+  name: ['apt-transport-https', 'ca-certificates']
+  state: 'present'
 
 
-# We must inform apt about the docker public key.
+# We must inform apt about the docker public key
 - name: 'add docker key'
   apt_key:
     url: 'https://download.docker.com/linux/ubuntu/gpg'
@@ -22,15 +18,9 @@
     state: 'present'
   register: 'add_repository_key'
   ignore_errors: true
-  loop: '{{groups.docker_node}}'
 
 
-# Add the official docker apt repository so that `apt`
-# can list packages from it and then fetch them from
-# there.
-# With `update_cache` we force an `apt update` which
-# would essentially be the equivalent of updating the
-# list of packages from a list of source repositories.
+# Add the official docker apt repository
 - name: 'add Docker repository'
   apt_repository:
     repo: '{{ docker_apt_repository }}'
@@ -43,7 +33,6 @@
   apt:
     name: 'docker-ce'
     state: 'present'
-  loop: '{{groups.docker_node}}'
 
 
 # Enable docker as service by default
@@ -52,7 +41,6 @@
     name: 'docker'
     state: 'started'
     enabled: 'yes'
-  loop: '{{groups.docker_node}}'
 
 
 # Configure the docker daemon via the configuration
@@ -61,7 +49,6 @@
   copy:
     src: 'daemon.json'
     dest: '/etc/docker/daemon.json'
-  loop: '{{groups.docker_node}}'
 
 # Prune dangling containers by setting a cron job to clean thing ups
 - name: 'set periodic docker system prune'
@@ -70,7 +57,6 @@
     minute: '0'
     hour: '*/2'
     job: 'docker container prune -f'
-  loop: '{{groups.docker_node}}'
 
 
 # Add unprivileged users to the `docker` group
@@ -81,5 +67,4 @@
     append: 'yes'
   with_items: '{{ docker_group_members }}'
   when: 'docker_group_members is defined'
-  loop: '{{groups.docker_node}}'
 

--- a/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+# Install the following deps:
+# 1) apt-transport-https to enable
+#   TLS in the transport of packages coming
+#   from APT repositories
+# 2) ca-certificates, a bundle of common certificate authorities' certificates
+- name: 'install docker dependencies'
+  apt:
+    name: '{{ item }}'
+    state: 'present'
+  with_items:
+    - 'apt-transport-https'
+    - 'ca-certificates'
+  loop: '{{groups.docker_node}}'
+
+
+# We must inform apt about the docker public key.
+- name: 'add docker key'
+  apt_key:
+    url: 'https://download.docker.com/linux/ubuntu/gpg'
+    id: '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+    state: 'present'
+  register: 'add_repository_key'
+  ignore_errors: true
+  loop: '{{groups.docker_node}}'
+
+
+# Add the official docker apt repository so that `apt`
+# can list packages from it and then fetch them from
+# there.
+# With `update_cache` we force an `apt update` which
+# would essentially be the equivalent of updating the
+# list of packages from a list of source repositories.
+- name: 'add Docker repository'
+  apt_repository:
+    repo: '{{ docker_apt_repository }}'
+    state: 'present'
+    update_cache: 'yes'
+
+
+# Install the latest docker CE
+- name: 'install docker Community Edition'
+  apt:
+    name: 'docker-ce'
+    state: 'present'
+  loop: '{{groups.docker_node}}'
+
+
+# Enable docker as service by default
+- name: 'enable docker systemd service'
+  service:
+    name: 'docker'
+    state: 'started'
+    enabled: 'yes'
+  loop: '{{groups.docker_node}}'
+
+
+# Configure the docker daemon via the configuration
+# file /etc/docker/daemon.json
+- name: 'prepare default daemon configuration'
+  copy:
+    src: 'daemon.json'
+    dest: '/etc/docker/daemon.json'
+  loop: '{{groups.docker_node}}'
+
+# Prune dangling containers by setting a cron job to clean thing ups
+- name: 'set periodic docker system prune'
+  cron:
+    name: 'docker-prune'
+    minute: '0'
+    hour: '*/2'
+    job: 'docker container prune -f'
+  loop: '{{groups.docker_node}}'
+
+
+# Add unprivileged users to the `docker` group
+- name: 'add users to docker group'
+  user:
+    name: '{{ item }}'
+    groups: 'docker'
+    append: 'yes'
+  with_items: '{{ docker_group_members }}'
+  when: 'docker_group_members is defined'
+  loop: '{{groups.docker_node}}'
+

--- a/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/docker-ce/tasks/main.yml
@@ -6,9 +6,8 @@
 # 2) ca-certificates, a bundle of common certificate authorities' certificates
 - name: 'install docker dependencies'
   apt:
-  name: ['apt-transport-https', 'ca-certificates']
-  state: 'present'
-
+    name: ['apt-transport-https', 'ca-certificates']
+    state: 'present'
 
 # We must inform apt about the docker public key
 - name: 'add docker key'

--- a/elasticluster/share/playbooks/roles/docker.yml
+++ b/elasticluster/share/playbooks/roles/docker.yml
@@ -1,0 +1,7 @@
+---
+- name: Docker Playbook
+  hosts: docker_node
+  tags:
+    - docker
+  roles:
+    - role: 'docker-ce'


### PR DESCRIPTION
@riccardomurri I've added a playbook to install and activate Docker Community Edition on nodes marked as docker_node.

The following configuration shows how to request a docker installation on the 3 worker nodes of a grid engine cluster:

```shell
[setup/gridengine]
provider=ansible
frontend_groups=gridengine_master
compute_groups=gridengine_worker,docker_node

[cluster/gridengine]
...
setup=gridengine
frontend_nodes=1
compute_nodes=3
```
Tests have been made on Ubuntu nodes on both Microsoft Azure and Google Compute Engine. There is nothing that binds the playbook and its roles to Ubuntu, therefore it should work on any Linux flavor.
