### PR TITLE
sergio: fix for issue 602

### DIFF
--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -402,6 +402,9 @@ def _read_config_files(paths):
     """
     # read given config files
     configparser = SafeConfigParser()
+    # Preventing automatic lowercase of config keys
+    # see: https://stackoverflow.com/questions/19359556/configparser-reads-capital-keys-and-make-them-lower-case
+    configparser.optionxform = str
     configparser.read(paths)
     # temporarily modify environment to allow both `${...}` and `%(...)s`
     # variable substitution in config values


### PR DESCRIPTION
set optionxform to `str` to avoind config keys being lowercased.

S.