### PR TITLE
Enable clusters to be paused and restarted.

### DIFF
--- a/elasticluster/__main__.py
+++ b/elasticluster/__main__.py
@@ -52,6 +52,8 @@ from elasticluster.subcommands import (
     SshFrontend,
     Start,
     Stop,
+    Resume,
+    Pause,
 )
 from elasticluster.conf import Creator
 from elasticluster.exceptions import ConfigurationError
@@ -98,6 +100,8 @@ class ElastiCluster(cli.app.CommandLineApp):
         # subcommands.abstract_command contract
         commands = [Start(self.params),
                     Stop(self.params),
+                    Pause(self.params),
+                    Resume(self.params),
                     ListClusters(self.params),
                     ListNodes(self.params),
                     ListTemplates(self.params),

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -748,7 +748,7 @@ class Cluster(Struct):
         """Pause all VMs in this cluster and store data so that they
         can be restarted later.
         """
-        log.debug("Pausing cluster `%s`", self.name)
+        log.info("Pausing cluster `%s` ...", self.name)
         failed = self._pause_all_nodes()
         if os.path.exists(self.known_hosts_file):
             os.remove(self.known_hosts_file)
@@ -765,7 +765,7 @@ class Cluster(Struct):
         """
         Resume all paused VMs in this cluster.
         """
-        log.debug("Resuming cluster `%s`", self.name)
+        log.info("Resuming cluster `%s` ...", self.name)
         failed = self._resume_all_nodes()
         for node in self.get_all_nodes():
             node.update_ips()

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -779,6 +779,12 @@ class Cluster(Struct):
                     "restarted.  Check error messages above and consider "
                     "re-running `elasticluster resume %s` if "
                     "necessary.", self.name)
+            return
+        self._run_resume_provisioner()
+        if not self._setup_provider.resume_cluster(self):
+            log.warning("Elasticluster was not able to guarantee that the "
+                        "cluster restarted correctly - check the errors "
+                        "above and check your config.")
 
     def _delete_saved_data(self):
         self._setup_provider.cleanup(self)
@@ -861,6 +867,9 @@ class Cluster(Struct):
         for node_name in successfully_resumed:
             del self.paused_nodes[node_name]
         return len(self.paused_nodes)
+
+    def _run_resume_provisioner(self):
+        pass
 
     def get_ssh_to_node(self, ssh_to=None):
         """

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -775,7 +775,6 @@ class Cluster(Struct):
         if failed:
             log.warning(
                     "Not all cluster nodes have been successfully "
-                    "stopped.  Some nodes may still be running - "
                     "restarted.  Check error messages above and consider "
                     "re-running `elasticluster resume %s` if "
                     "necessary.", self.name)

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -1322,7 +1322,7 @@ class Node(Struct):
         if self.instance_id is None:
             raise ValueError("Trying to stop unstarted node.")
         resp = self._cloud_provider.pause_instance(self.instance_id)
-        self.update_ips()
+        self.preferred_ip = None
         return resp
 
     def is_alive(self):

--- a/elasticluster/providers/__init__.py
+++ b/elasticluster/providers/__init__.py
@@ -68,6 +68,26 @@ class AbstractCloudProvider:
         pass
 
     @abstractmethod
+    def pause_instance(self, instance_id):
+        """Pauses the instance - retaining disks and configuration.
+
+        :param str instance_id: instance identifier
+
+        :return: dict - Dictionary of configuration required to restart instance.
+        """
+        pass
+
+    @abstractmethod
+    def resume_instance(self, instance_config):
+        """Restart an instance from a dictionary of configuration.
+
+        :param dict instance_config - Dictionary of configuration returned
+                                      from pause_instance
+        :return: str - instance_id
+        """
+        pass
+
+    @abstractmethod
     def stop_instance(self, instance_id):
         """Stops the instance gracefully.
 

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -362,6 +362,12 @@ class AzureCloudProvider(AbstractCloudProvider):
                 oper.wait()
                 self._inventory = {}
 
+    def resume_instance(self, instance_state):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
+    def pause_instance(self, instance_id):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
 
     def get_ips(self, instance_id):
         """

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -361,6 +361,12 @@ class BotoCloudProvider(AbstractCloudProvider):
         instance.terminate()
         del self._instances[instance_id]
 
+    def resume_instance(self, instance_state):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
+    def pause_instance(self, instance_id):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
     def get_ips(self, instance_id):
         """Retrieves the private and public ip addresses for a given instance.
 

--- a/elasticluster/providers/libcloud_provider.py
+++ b/elasticluster/providers/libcloud_provider.py
@@ -189,6 +189,12 @@ class LibCloudProvider(AbstractCloudProvider):
         log.info('stopping %s', instance.name)
         instance.destroy()
 
+    def resume_instance(self, instance_state):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
+    def pause_instance(self, instance_id):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
     def get_ips(self, instance_id):
         instance = self.__get_instance(instance_id)
         if not instance:

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -569,6 +569,12 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         instance.delete()
         del self._instances[instance_id]
 
+    def resume_instance(self, instance_state):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
+    def pause_instance(self, instance_id):
+        raise NotImplementedError("This provider does not support pause / resume logic.")
+
     def get_ips(self, instance_id):
         """Retrieves all IP addresses associated to a given instance.
 

--- a/elasticluster/share/playbooks/resume.yml
+++ b/elasticluster/share/playbooks/resume.yml
@@ -1,15 +1,4 @@
 ---
-- name: Prepare VM for running Ansible
-  hosts: all
-  gather_facts: no
-  tasks:
-    - name: Ensure Python is installed
-      script: |
-        install-py2.sh {{ ansible_python_interpreter|default("/usr/bin/python") }}
-      args:
-        creates: '{{ ansible_python_interpreter|default("/usr/bin/python") }}'
-      become: yes
-
 # for local customizations
 - import_playbook: before.yml
 
@@ -48,6 +37,9 @@
 # Remaining cluster types may or may not work after resuming.
 #
 # Report success, as all went well!
+
+- import_playbook: after.yml
+
 - name: Report success on cluster creation
   hosts: all
   gather_facts: no

--- a/elasticluster/share/playbooks/resume.yml
+++ b/elasticluster/share/playbooks/resume.yml
@@ -23,6 +23,9 @@
 - name: Handle potential IP changes.
   hosts: all
   tasks:
+    - name: Set up environment
+      include_tasks: roles/common/tasks/pre.yml
+
     - name: Set hostnames.
       include_tasks: roles/common/tasks/hostname.yml
 
@@ -41,7 +44,7 @@
 # additional customization.
 # - import_playbook: roles/gridengine-resume.yml
 # - import_playbook: roles/hadoop-resume.yml
-# 
+#
 # Remaining cluster types may or may not work after resuming.
 #
 # Report success, as all went well!

--- a/elasticluster/share/playbooks/resume.yml
+++ b/elasticluster/share/playbooks/resume.yml
@@ -1,0 +1,60 @@
+---
+- name: Prepare VM for running Ansible
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Ensure Python is installed
+      script: |
+        install-py2.sh {{ ansible_python_interpreter|default("/usr/bin/python") }}
+      args:
+        creates: '{{ ansible_python_interpreter|default("/usr/bin/python") }}'
+      become: yes
+
+# for local customizations
+- import_playbook: before.yml
+
+# First, perform important setup tasks, like resetting hostnames
+# to the ansible-known inventory names, and pushing up a new
+# and correct /etc/hosts, in the event that either hostname
+# or ip addresses have changed on restart.  These are
+# standard behavior on at least one cloud each, and are
+# idempotent and therefore safe to apply on all clouds.
+
+- name: Handle potential IP changes.
+  hosts: all
+  tasks:
+    - name: Set hostnames.
+      include_tasks: roles/common/tasks/hostname.yml
+
+    - name: Push up hosts files.
+      include_tasks: roles/common/tasks/hosts.yml
+
+# Next, ensure that the services that run this cluster are
+# started.  It's common for a service to fail to restart
+# during machine boot (because, e.g. it cannot contact the
+# master, whose ip address has changed).  Cluster-type
+# specific updates may also be listed in these playbooks.
+
+# - import_playbook: roles/gridengine-resume.yml
+# - import_playbook: roles/hadoop-resume.yml
+# - import_playbook: roles/htcondor-resume.yml
+# - import_playbook: roles/ipython-resume.yml
+# - import_playbook: roles/jenkins-resume.yml
+# - import_playbook: roles/kubernetes-resume.yml
+# - import_playbook: roles/pbspro-resume.yml
+- import_playbook: roles/slurm-resume.yml
+# - import_playbook: roles/torque-resume.yml
+#
+#
+# Report success, as all went well!
+- name: Report success on cluster creation
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Mark host as successfully configured
+      shell: |
+        echo 'done' > '{{ elasticluster.output_dir }}/{{ inventory_hostname }}.log'
+      delegate_to: 'localhost'
+      # this is necessary as we might not have/want superuser rights
+      # where ElastiCluster is running
+      become: no

--- a/elasticluster/share/playbooks/resume.yml
+++ b/elasticluster/share/playbooks/resume.yml
@@ -35,16 +35,14 @@
 # master, whose ip address has changed).  Cluster-type
 # specific updates may also be listed in these playbooks.
 
+- import_playbook: roles/slurm-resume.yml
+#
+# These cluster types have been confirmed not to need
+# additional customization.
 # - import_playbook: roles/gridengine-resume.yml
 # - import_playbook: roles/hadoop-resume.yml
-# - import_playbook: roles/htcondor-resume.yml
-# - import_playbook: roles/ipython-resume.yml
-# - import_playbook: roles/jenkins-resume.yml
-# - import_playbook: roles/kubernetes-resume.yml
-# - import_playbook: roles/pbspro-resume.yml
-- import_playbook: roles/slurm-resume.yml
-# - import_playbook: roles/torque-resume.yml
-#
+# 
+# Remaining cluster types may or may not work after resuming.
 #
 # Report success, as all went well!
 - name: Report success on cluster creation

--- a/elasticluster/share/playbooks/roles/bigtop/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/bigtop/tasks/main.yml
@@ -17,7 +17,14 @@
     url: '{{ bigtop_mirror }}/bigtop/bigtop-{{bigtop_release}}/repos/{{ansible_distribution|lower}}{{ansible_distribution_version}}/bigtop.list'
     dest: '/etc/apt/sources.list.d/bigtop.list'
   register: _bigtop_add_apt_repo
+  when: is_ubuntu
 
+- name: add Apache Bigtop repository
+  get_url:
+    url: '{{ bigtop_mirror }}/bigtop/bigtop-{{bigtop_release}}/repos/{{ansible_distribution|lower}}{{ansible_distribution_major_version}}/bigtop.list'
+    dest: '/etc/apt/sources.list.d/bigtop.list'
+  register: _bigtop_add_apt_repo
+  when: not is_ubuntu
 
 # this is run as task and not as a handler, since handlers are all
 # executed after *all* tasks in the play have run, and we need the

--- a/elasticluster/share/playbooks/roles/common/tasks/hosts.yml
+++ b/elasticluster/share/playbooks/roles/common/tasks/hosts.yml
@@ -2,6 +2,6 @@
 - name: Set /etc/hosts from Ansible hostgroups
   template:
     dest: /etc/hosts
-    src: etc/hosts.j2
+    src: roles/common/templates/etc/hosts.j2
     owner: root
     group: root

--- a/elasticluster/share/playbooks/roles/common/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/common/tasks/main.yml
@@ -1,21 +1,6 @@
 ---
 
-- name: Provide workaround for YAML syntax error in lines containing colon+space
-  set_fact:
-    __colon__: ':'
-  tags:
-    - cloud-init
-
-- name: Allow package updates
-  set_fact:
-    pkg_install_state: 'latest'
-  when: 'upgrade_packages|default(True)|bool'
-
-- name: Disallow package updates
-  set_fact:
-    pkg_install_state: 'present'
-  when: 'not upgrade_packages|default(True)|bool'
-
+- include_tasks: pre.yml
 - include_tasks: 'init-{{ansible_os_family}}.yml'
 - include_tasks: hosts.yml
   vars:

--- a/elasticluster/share/playbooks/roles/common/tasks/pre.yml
+++ b/elasticluster/share/playbooks/roles/common/tasks/pre.yml
@@ -1,0 +1,20 @@
+---
+#
+# A few environment setup tasks that may be needed by any other playbook.
+#
+
+- name: Provide workaround for YAML syntax error in lines containing colon+space
+  set_fact:
+    __colon__: ':'
+  tags:
+    - cloud-init
+
+- name: Allow package updates
+  set_fact:
+    pkg_install_state: 'latest'
+  when: 'upgrade_packages|default(True)|bool'
+
+- name: Disallow package updates
+  set_fact:
+    pkg_install_state: 'present'
+  when: 'not upgrade_packages|default(True)|bool'

--- a/elasticluster/share/playbooks/roles/jupyter/tasks/python.yml
+++ b/elasticluster/share/playbooks/roles/jupyter/tasks/python.yml
@@ -39,7 +39,7 @@
         # PostGreSQL
         - libpq-dev
         # MySQL compatible
-        - libmysqlclient-dev
+        - default-libmysqlclient-dev
       RedHat:
         - postgresql-devel
     jupyter_additional_python_packages:

--- a/elasticluster/share/playbooks/roles/jupyterhub/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/jupyterhub/tasks/main.yml
@@ -21,16 +21,21 @@
     - /etc/jupyterhub
     - /var/lib/jupyterhub
 
+- name: Nodejs apt signing key
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
+- name: Nodejs apt repo
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_8.x {{ansible_distribution_release}} main
+    state: present
 
 - name: Install SW dependencies
   apt:
-    name: '{{item}}'
+    name: 'nodejs'
     state: '{{ pkg_install_state }}'
     allow_unauthenticated: '{{ not insecure_https_downloads|default("no")|bool }}'
-  loop:
-    - nodejs-legacy
-    - npm
-
 
 - name: Install JupyterHub
   command: |

--- a/elasticluster/share/playbooks/roles/slurm-resume.yml
+++ b/elasticluster/share/playbooks/roles/slurm-resume.yml
@@ -4,7 +4,7 @@
   hosts: slurm_master
   tasks:
     - service:
-        name=slurmctld
+        name: slurmctld
         state=restarted
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:

--- a/elasticluster/share/playbooks/roles/slurm-resume.yml
+++ b/elasticluster/share/playbooks/roles/slurm-resume.yml
@@ -28,9 +28,19 @@
         path: /var/run/slurm-llnl
         state: directory
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
-    - service:
+
+    - name: Get running slurm processes
+      shell: "ps -ef | grep -v grep | grep -w slurmd | awk '{print $2}'"
+      register: running_slurm
+      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - name: Kill running slurm processes
+      shell: "kill -9 {{ item }}"
+      with_items: "{{ running_slurm.stdout_lines }}"
+      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+
+    - systemd:
         name: slurmd
-        state: restarted
+        state: started
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
         name: slurm-llnl

--- a/elasticluster/share/playbooks/roles/slurm-resume.yml
+++ b/elasticluster/share/playbooks/roles/slurm-resume.yml
@@ -28,16 +28,9 @@
         path: /var/run/slurm-llnl
         state: directory
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
-
-    - name: Get running slurm processes
-      shell: "ps -ef | grep -v grep | grep -w slurmd | awk '{print $2}'"
-      register: running_slurm
+    - name: Kill any running slurm processes
+      shell: "killall -w -g slurmd"
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
-    - name: Kill running slurm processes
-      shell: "kill -9 {{ item }}"
-      with_items: "{{ running_slurm.stdout_lines }}"
-      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
-
     - systemd:
         name: slurmd
         state: started

--- a/elasticluster/share/playbooks/roles/slurm-resume.yml
+++ b/elasticluster/share/playbooks/roles/slurm-resume.yml
@@ -5,19 +5,19 @@
   tasks:
     - service:
         name: slurmctld
-        state=restarted
+        state: restarted
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
-        name=slurmctl-llnl
-        state=restarted
+        name: slurmctl-llnl
+        state: restarted
       when: 'is_debian_compatible and not (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
-        name=slurmctld
-        state=restarted
+        name: slurmctld
+        state: restarted
       when: is_rhel7_compatible
     - service:
-        name=slurmctl
-        state=restarted
+        name: slurmctl
+        state: restarted
       when: is_rhel6_compatible
 
 - name: Restart SLURMd
@@ -29,18 +29,18 @@
         state: directory
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
-        name=slurmd
-        state=restarted
+        name: slurmd
+        state: restarted
       when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
-        name=slurm-llnl
-        state=restarted
+        name: slurm-llnl
+        state: restarted
       when: 'is_debian_compatible and not (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
     - service:
-        name=slurmd
-        state=restarted
+        name: slurmd
+        state: restarted
       when: is_rhel7_compatible
     - service:
-        name=slurm
-        state=restarted
+        name: slurm
+        state: restarted
       when: is_rhel6_compatible

--- a/elasticluster/share/playbooks/roles/slurm-resume.yml
+++ b/elasticluster/share/playbooks/roles/slurm-resume.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Restart SLURMcltd
+  hosts: slurm_master
+  tasks:
+    - service:
+        name=slurmctld
+        state=restarted
+      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - service:
+        name=slurmctl-llnl
+        state=restarted
+      when: 'is_debian_compatible and not (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - service:
+        name=slurmctld
+        state=restarted
+      when: is_rhel7_compatible
+    - service:
+        name=slurmctl
+        state=restarted
+      when: is_rhel6_compatible
+
+- name: Restart SLURMd
+  hosts: slurm_worker
+  tasks:
+    - name: Create pidfile directory to deal with slurm restart bug.
+      file:
+        path: /var/run/slurm-llnl
+        state: directory
+      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - service:
+        name=slurmd
+        state=restarted
+      when: 'is_debian_compatible and (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - service:
+        name=slurm-llnl
+        state=restarted
+      when: 'is_debian_compatible and not (is_debian_8_or_later or is_ubuntu_15_10_or_later)'
+    - service:
+        name=slurmd
+        state=restarted
+      when: is_rhel7_compatible
+    - service:
+        name=slurm
+        state=restarted
+      when: is_rhel6_compatible


### PR DESCRIPTION
This has five core changes.
- adds `pause` command, which stores a dictionary of information about nodes.
- adds `resume` command, which takes that dictionary and starts the node back up.
- implements both of those for GCE.
- creates a top-level playbook (`resume.yml`) which runs after restart.
- fixes a couple bugs in ansible playbooks I found while testing it.

This fixes #583.

There's a couple things it doesn't do yet - it doesn't have control of thread count plumbed through to the command line, for instance - but I wanted to get it out there for a first pass of review.