### PR TITLE
Set user agent to elasticluster when making requests to gce.

### DIFF
--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -43,6 +43,7 @@ from oauth2client.file import Storage
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.tools import run_flow
 from oauth2client.tools import argparser
+import pkg_resources
 
 # Elasticluster imports
 from elasticluster import log
@@ -166,7 +167,8 @@ class GoogleCloudProvider(AbstractCloudProvider):
                         log.debug("(Original traceback follows.)", exc_info=True)
                         raise
 
-                http = googleapiclient.http.set_user_agent(httplib2.Http(), "elasticluster")
+                version = pkg_resources.get_distribution("elasticluster").version
+                http = googleapiclient.http.set_user_agent(httplib2.Http(), "elasticluster/%s" % version)
                 self._auth_http = credentials.authorize(http)
 
                 self._gce = build(GCE_API_NAME, GCE_API_VERSION, http=http)

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -38,6 +38,7 @@ import uuid
 # External modules
 from apiclient.discovery import build
 from apiclient.errors import HttpError
+import googleapiclient
 from oauth2client.file import Storage
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.tools import run_flow
@@ -165,7 +166,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                         log.debug("(Original traceback follows.)", exc_info=True)
                         raise
 
-                http = httplib2.Http()
+                http = googleapiclient.http.set_user_agent(httplib2.Http(), "elasticluster")
                 self._auth_http = credentials.authorize(http)
 
                 self._gce = build(GCE_API_NAME, GCE_API_VERSION, http=http)


### PR DESCRIPTION
Note: I believe that this doesn't introduce a new dependency - apiclient depends on googleapiclient, so we should always have this module imported.  In any event, it runs fine without any additional packages in a virtualenv that only contains elasticluster, so I feel pretty confident in it.