### PR TITLE
Make travis show green for external contributors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ sudo: false
 
 after_success:
   - if [ $(echo "$TRAVIS_PYTHON_VERSION" | cut -d. -f1-2) != '2.7' ]; then echo "Only building on Py2.7, this is $TRAVIS_PYTHON_VERSION"; exit 0; fi
+  - if [ -z "$DOCKER_USER" ]; then echo "Untrusted build - cannot access docker environment variables."; exit 0; fi
   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
   - export BRANCH=$(echo "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" | cut -c-8)
   - export COMMIT=$(echo "${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}" | cut -c-8)


### PR DESCRIPTION
If the build isn't allowed access to secure variables, don't try to run the docker build.