### PR TITLE
ENH: Submit coverage report to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ after_success:
   - docker tag $DOCKER_DEST:$COMMIT $DOCKER_DEST:$TAG
   - docker tag $DOCKER_DEST:$COMMIT $DOCKER_DEST:travis-$TRAVIS_BUILD_NUMBER
   - docker push $DOCKER_DEST
+  - codecov


### PR DESCRIPTION
Since the repository is public, this service is free and should be very easy to enable.  Someone with sufficient privileges should just login through github and enable codecov report for this repo. 
With [sourcegraph](https://github.com/codecov/sourcegraph-codecov/blob/master/README.md) browser extension it becomes then really handy to see what lines of diff in PR are covered by tests and which not.