### PR TITLE
Azure deployment: managed disks and disk size. Plus fix for Python 3.

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -1032,6 +1032,14 @@ node-level section take precedence over cluster-wide ones.
 
        .. __: https://github.com/gc3-uzh-ch/elasticluster/issues/490
 
+Additional optional configuration keys for Azure
+-----------------------------------------------------
+
+
+``boot_disk_size``
+    Size of the instance's root filesystem volume, in Gibibytes (GiB).
+    The ``/home`` directory of this volume on the first frontend node
+    is shared to compute nodes using NFS. Defaults to 30.
 
 Additional optional configuration keys for Amazon EC2
 -----------------------------------------------------
@@ -1048,7 +1056,7 @@ well, to place nodes on spot instances.
 ``boot_disk_size``
     Size of the instance's root filesystem volume, in Gibibytes (GiB).
     The ``/home`` directory of this volume on the first frontend node
-    is shared to compute nodes using NFS.  Defaults to the original
+    is shared to compute nodes using NFS. Defaults to the original
     size of the base AMI specified by ``image_id``.
 
 ``boot_disk_type``

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -188,7 +188,10 @@ class AzureCloudProvider(AbstractCloudProvider):
 
     def start_instance(self, key_name, public_key_path, private_key_path,
                        security_group, flavor, image_id, image_userdata,
-                       username='root', node_name=None, **extra):
+                       username='root',
+                       node_name=None,
+                       boot_disk_size=30,
+                       **extra):
         """
         Start a new VM using the given properties.
 
@@ -208,6 +211,8 @@ class AzureCloudProvider(AbstractCloudProvider):
           (e.g., ``canonical/ubuntuserver/16.04.0-LTS/latest``)
         :param str image_userdata:
           command to execute after startup, **currently unused**
+        :param int boot_disk_size:
+          size of boot disk to use; values are specified in gigabytes.
         :param str username:
           username for the given ssh key
           (default is ``root`` as it's always guaranteed to exist,
@@ -270,6 +275,7 @@ class AzureCloudProvider(AbstractCloudProvider):
                     })
                 oper.wait()
                 self._networks_created.add(net_name)
+        boot_disk_size_gb = int(boot_disk_size)
 
         vm_parameters = {
             'adminUserName':  { 'value': username },
@@ -288,6 +294,7 @@ class AzureCloudProvider(AbstractCloudProvider):
             'subnetName':     { 'value': cluster_name },
             'vmName':         { 'value': node_name },
             'vmSize':         { 'value': flavor },
+            'bootDiskSize':   { 'value': boot_disk_size_gb}
         }
         log.debug(
             "Deploying `%s` VM template to Azure ...",

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -327,8 +327,8 @@ class AzureCloudProvider(AbstractCloudProvider):
     @staticmethod
     def _make_storage_account_name(cluster_name, node_name):
         algo = hashlib.md5()
-        algo.update(cluster_name)
-        algo.update(node_name)
+        algo.update(cluster_name.encode('utf-8'))
+        algo.update(node_name.encode('utf-8'))
         # the `storageAccountName` parameter must be lowercase
         # alphanumeric and between 3 and 24 characters long... We
         # cannot use base64 encoding, and the full MD5 hash is 32

--- a/elasticluster/share/etc/azure_vm_template.json
+++ b/elasticluster/share/etc/azure_vm_template.json
@@ -48,7 +48,7 @@
     "storageAccountName": {
       "type": "string",
       "metadata": {
-          "description": "Unique alphanumeric identifier."
+        "description": "Unique alphanumeric identifier."
       }
     },
     "subnetName": {
@@ -76,6 +76,13 @@
       "metadata": {
         "description": "Size of the VM"
       }
+    },
+    "bootDiskSize": {
+      "type": "int",
+      "defaultValue": 30,
+      "metadata": {
+        "description": "Size of boot disk to use; values are specified in gigabytes."
+      }
     }
   },
   "variables": {
@@ -88,23 +95,47 @@
     "nicName": "[concat(parameters('vmName'), '-nic')]",
     "publicIPAddressName": "[concat(parameters('vmName'), '-public-ip')]",
     "publicIPAddressType": "Dynamic",
-    "storageAccountType": "Standard_LRS",
     "networkSecurityGroupName": "[concat(resourceGroup().name, '-secgroup')]",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
-    "apiVersion": "2015-06-15"
+    "apiVersion": "2018-10-01"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2018-07-01",
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
       "location": "[variables('location')]",
+      "tags": {},
+      "scale": null,
+      "kind": "Storage",
       "properties": {
-        "accountType": "[variables('storageAccountType')]"
+        "networkAcls": {
+          "bypass": "AzureServices",
+          "virtualNetworkRules": [],
+          "ipRules": [],
+          "defaultAction": "Allow"
+        },
+        "supportsHttpsTrafficOnly": false,
+        "encryption": {
+          "services": {
+            "file": {
+              "enabled": true
+            },
+            "blob": {
+              "enabled": true
+            }
+          },
+          "keySource": "Microsoft.Storage"
+        }
       }
     },
+
     {
       "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
@@ -200,9 +231,10 @@
       "name": "[parameters('vmName')]",
       "location": "[variables('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[resourceId('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
+      "tags": {},
       "properties": {
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
@@ -227,15 +259,16 @@
             "publisher": "[parameters('imagePublisher')]",
             "offer": "[parameters('imageOffer')]",
             "sku": "[parameters('imageSku')]",
-            "version": "latest"
+            "version": "[parameters('imageVersion')]"
           },
           "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/', variables('osDiskName'),'.vhd')]"
-            },
+            "createOption": "FromImage",
+            "name": "[variables('osDiskName')]",
             "caching": "ReadWrite",
-            "createOption": "FromImage"
+            "diskSizeGB": "[parameters('bootDiskSize')]",
+            "managedDisk": {
+              "storageAccountType": "StandardSSD_LRS"
+            }
           }
         },
         "networkProfile": {


### PR DESCRIPTION
In the first commit, I extended the Azure deployment to use managed disks on the nodes and added the possibility to set the boot disk size with a new parameter from the cluster configuration file.

In the second commit, I fixed the following deployment error: 
```
gc3.elasticluster[14] ERROR Could not start node `compute001`: Unicode-objects must be encoded before hashing -- <class 'TypeError'>
Traceback (most recent call last):
  File "/elasticluster-src/elasticluster/cluster.py", line 580, in _start_node
    node.start()
  File "/elasticluster-src/elasticluster/cluster.py", line 1318, in start
    **self.extra)
  File "/elasticluster-src/elasticluster/providers/azure_provider.py", line 292, in start_instance
    cluster_name, node_name)
  File "/elasticluster-src/elasticluster/providers/azure_provider.py", line 330, in _make_storage_account_name
    algo.update(cluster_name)
TypeError: Unicode-objects must be encoded before hashing

```
I was getting this error while creating Azure clusters with python 3.7.3. Other than that, deployments on Azure seem to be working well. 