### PR TITLE
Encode cluster and node names on Azure.

### DIFF
--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -320,8 +320,8 @@ class AzureCloudProvider(AbstractCloudProvider):
     @staticmethod
     def _make_storage_account_name(cluster_name, node_name):
         algo = hashlib.md5()
-        algo.update(cluster_name)
-        algo.update(node_name)
+        algo.update(cluster_name.encode('utf-8'))
+        algo.update(node_name.encode('utf-8'))
         # the `storageAccountName` parameter must be lowercase
         # alphanumeric and between 3 and 24 characters long... We
         # cannot use base64 encoding, and the full MD5 hash is 32


### PR DESCRIPTION
This fixes the following deployment error on Azure emerged after the migration to Python 3:

```
gc3.elasticluster[14] ERROR Could not start node `compute001`: Unicode-objects must be encoded before hashing -- <class 'TypeError'>
Traceback (most recent call last):
  File "/elasticluster-src/elasticluster/cluster.py", line 580, in _start_node
    node.start()
  File "/elasticluster-src/elasticluster/cluster.py", line 1318, in start
    **self.extra)
  File "/elasticluster-src/elasticluster/providers/azure_provider.py", line 292, in start_instance
    cluster_name, node_name)
  File "/elasticluster-src/elasticluster/providers/azure_provider.py", line 330, in _make_storage_account_name
    algo.update(cluster_name)
TypeError: Unicode-objects must be encoded before hashing
```
