### PR TITLE
Azure: deployment error with names

### DIFF
--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -266,13 +266,13 @@ class AzureCloudProvider(AbstractCloudProvider):
         # line 1182)
         cluster_name, _ = node_name.split('-', 1)
         if not self.__compiled_pattern.match(cluster_name):
-            raise ConfigurationError("The cluster name {0} does not match the Azure requirement for names. "
-                                     "It must conform to the following regular expression: {1}"
+            raise ConfigurationError("The cluster name `{0}` does not match the Azure requirement for names. "
+                                     "It must conform to the following regular expression: `{1}`"
                                      .format(cluster_name, self.__pattern_for_name))
 
         if not self.__compiled_pattern.match(node_name):
-            raise ConfigurationError("The node name {0} does not match the Azure requirement for names. "
-                                     "It must conform to the following regular expression: {1}"
+            raise ConfigurationError("The node name `{0}` does not match the Azure requirement for names. "
+                                     "It must conform to the following regular expression: `{1}`"
                                      .format(node_name, self.__pattern_for_name))
         with self.__lock:
             if cluster_name not in self._resource_groups_created:

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -105,8 +105,7 @@ class AzureCloudProvider(AbstractCloudProvider):
     An AzureCloudProvider owns a tree of Azure resources, rooted in one or
     more subscriptions and one or more storage accounts.
     """
-    __pattern_for_name = "^[a-z][a-z0-9-]{1,61}[a-z0-9]$"
-    __compiled_pattern = re.compile(__pattern_for_name)
+    __compiled_pattern_for_names = re.compile("^[a-z][a-z0-9-]{1,61}[a-z0-9]$")
 
 
     __lock = threading.Lock()
@@ -265,15 +264,19 @@ class AzureCloudProvider(AbstractCloudProvider):
         # the substring before the leftmost dash (see `cluster.py`,
         # line 1182)
         cluster_name, _ = node_name.rsplit('-', 1)
-        if not self.__compiled_pattern.match(cluster_name):
+        if not self.__compiled_pattern_for_names.match(cluster_name):
             raise ConfigurationError("The cluster name `{0}` does not match the Azure requirement for names. "
-                                     "It must conform to the following regular expression: `{1}`"
-                                     .format(cluster_name, self.__pattern_for_name))
+                                     "Only numbers, lowercase letters and dashes are allowed, "
+                                     "the value must begin with a lowercase letter and cannot end with a slash, "
+                                     "and must also be less than 63 characters long."
+                                     .format(cluster_name))
 
-        if not self.__compiled_pattern.match(node_name):
+        if not self.__compiled_pattern_for_names.match(node_name):
             raise ConfigurationError("The node name `{0}` does not match the Azure requirement for names. "
-                                     "It must conform to the following regular expression: `{1}`"
-                                     .format(node_name, self.__pattern_for_name))
+                                     "Only numbers, lowercase letters and dashes are allowed, "
+                                     "the value must begin with a lowercase letter and cannot end with a slash, "
+                                     "and must also be less than 63 characters long."
+                                     .format(node_name))
         with self.__lock:
             if cluster_name not in self._resource_groups_created:
                 self._resource_client.resource_groups.create_or_update(

--- a/elasticluster/providers/azure_provider.py
+++ b/elasticluster/providers/azure_provider.py
@@ -264,7 +264,7 @@ class AzureCloudProvider(AbstractCloudProvider):
         # extract it from the node name, which always contains it as
         # the substring before the leftmost dash (see `cluster.py`,
         # line 1182)
-        cluster_name, _ = node_name.split('-', 1)
+        cluster_name, _ = node_name.rsplit('-', 1)
         if not self.__compiled_pattern.match(cluster_name):
             raise ConfigurationError("The cluster name `{0}` does not match the Azure requirement for names. "
                                      "It must conform to the following regular expression: `{1}`"


### PR DESCRIPTION
I fixed a couple of problems I frequently encountered when deploying my clusters on Azure:

1. Azure does not accept capital letters, punctuation and, more in general, non-alphanumeric characters in the cluster and node names. Every time I was forgetting this and I used such characters in the cluster name, I got the following error:

```
Starting cluster ecmasterM with:
* 2 compute nodes.
* 1 frontend nodes.
(This may take a while...)
2019-04-29 01:51:45 f42736e87826 gc3.elasticluster[2484] ERROR Could not start node `compute002`: Azure Error: InvalidTemplateDeployment
Message: The template deployment 'ecmasterM-compute002' is not valid according to the validation procedure. The tracking id is 'd79ac3db-627b-43a6-9cd2-2975fa117e3e'. See inner errors for details. Please see https://aka.ms/arm-deploy for usage details.
Exception Details:
        Error Code: InvalidDomainNameLabel
        Message: The domain name label ecmasterM-compute002 is invalid.
```

This error was coming from the remote Azure counterpart, it was not local. The major issue with this was that the resource group was all the same created and some resources were also created in the group (the network interface, the security group, etc.). Then, there was no way to delete them with ElastiCluster (as the cluster was not valid). I needed to go to the Azure portal and delete them from there.
So I added two checks in the `start_instance` method of the Azure provider and they raise a Configuration Error if the name of the cluster or the node does not match the expected regex. I do not know if this issue occurs also with other cloud providers (I don't have a way to check now, I might in the coming weeks). If so, the new checks should be moved up in the providers' hierarchy.

2. The second issue I worked around was a corner case on the cluster name. If it contained a dash character (accepted by Azure), the resource group name was not correctly reconstructed from the node name. For instance, if the value for the cluster name was `mycluster-2019`, ElastiCluster was creating a cluster name `mycluster`.