### PR TITLE
Update mgr.yml to avoid error with ansible 2.8

### DIFF
--- a/elasticluster/share/playbooks/roles/ceph/tasks/mgr.yml
+++ b/elasticluster/share/playbooks/roles/ceph/tasks/mgr.yml
@@ -36,8 +36,10 @@
     keyname: '{{_ceph_daemon_name}}'
     capabilities: "--cap mon 'allow profile mgr' --cap osd 'allow *' --cap mds 'allow *'"
     keyring: '{{_ceph_daemon_dir}}/keyring'
-  become: yes
-  become_user: 'ceph'
+  args:
+    apply:
+      become: yes
+      become_user: 'ceph'
 
 
 - name: Register the MGR authentication key

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         'pip>=9.0.0',  ## see issue #433
         #'ara',  # optional
         'PyCLI',
-        'ansible>=2.5',
+        'ansible>=2.7',
         'click>=4.0',  ## click.prompt() added in 4.0
         'coloredlogs',
         'netaddr',


### PR DESCRIPTION
Ansible 2.8.0 complains with the syntax of mgr.yml
"ERROR! 'become' is not a valid attribute for a TaskInclude"
We are now using ansible 2.8 syntax (is it actually 2.7 syntax?).